### PR TITLE
Use pinia store for version data

### DIFF
--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -57,22 +57,20 @@
 
 <script lang="ts" setup>
 import { CIcon } from "@coreui/icons-vue";
-import type { VersionData } from "@/types/apiResponseTypes";
 
-const { data: versionData } = useFetch("/api/versions") as { data: Ref<VersionData> };
+const appStore = useAppStore();
+const { screenIsLarge, getVersions } = storeToRefs(appStore);
 
 const versionTooltipContent = computed(() => {
-  if (versionData.value) {
-    return `Model version: ${versionData.value.daedalusModel} \nR API version: ${versionData.value.daedalusApi} \nWeb app version: ${versionData.value.daedalusWebApp}`;
+  const vers = getVersions.value;
+  if (vers) {
+    return `Model version: ${vers.daedalusModel} \nR API version: ${vers.daedalusApi} \nWeb app version: ${vers.daedalusWebApp}`;
   } else {
     return undefined;
   }
 });
 
 const visible = defineModel("visible", { type: Boolean, required: true });
-
-const appStore = useAppStore();
-const { screenIsLarge } = storeToRefs(appStore);
 
 const resetSidebarPerScreenSize = () => {
   visible.value = screenIsLarge.value;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,7 +25,7 @@ function handleToggleSidebarVisibility() {
 }
 
 const appStore = useAppStore();
-await appStore.initializeAppState();
+appStore.initializeAppState();
 
 const setScreenSize = () => {
   const breakpoint = 992; // CoreUI's "lg" breakpoint

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,12 +24,10 @@ function handleToggleSidebarVisibility() {
   sidebarVisible.value = !sidebarVisible.value;
 }
 
-const appStore = useAppStore(useNuxtApp().$pinia);
-appStore.initializeAppState();
+const appStore = useAppStore();
+await appStore.initializeAppState();
 
 const setScreenSize = () => {
-  // As this function uses window, it can only be run client-side, so we have to pass the $pinia instance
-  // to the useAppStore function: https://pinia.vuejs.org/ssr/nuxt.html#Awaiting-for-actions-in-pages
   const breakpoint = 992; // CoreUI's "lg" breakpoint
   if (window.innerWidth < breakpoint) {
     appStore.setScreenSize(false);

--- a/pages/scenarios/index.vue
+++ b/pages/scenarios/index.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts" setup>
 // https://nuxt.com/docs/getting-started/data-fetching
-const { data: scenarios } = await useFetch("/api/scenarios");
+const { data: scenarios } = useFetch("/api/scenarios");
 </script>
 
 <style lang="scss" scoped>

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -1,18 +1,25 @@
 import { defineStore } from "pinia";
 import type { AppState } from "@/types/storeTypes";
+import type { VersionData } from "@/types/apiResponseTypes";
 
 export const useAppStore = defineStore("app", {
   state: (): AppState => ({
     largeScreen: true,
+    versions: undefined,
   }),
   getters: {
     screenIsLarge: (state: AppState): boolean => {
       return state.largeScreen;
     },
+    getVersions: (state: AppState): VersionData | undefined => {
+      return state.versions;
+    },
   },
   actions: {
-    initializeAppState(): void {
+    async initializeAppState() {
       this.largeScreen = true;
+      const { data: versionData } = await useFetch("/api/versions", { timeout: 100 }) as { data: Ref<VersionData> };
+      this.versions = versionData.value;
     },
     setScreenSize(bool: boolean): void {
       this.largeScreen = bool;

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -16,10 +16,20 @@ export const useAppStore = defineStore("app", {
     },
   },
   actions: {
-    async initializeAppState() {
+    initializeAppState(): void {
       this.largeScreen = true;
-      const { data: versionData } = await useFetch("/api/versions", { timeout: 100 }) as { data: Ref<VersionData> };
-      this.versions = versionData.value;
+
+      // Avoid using 'await', which would block the rest of the code including the component setup function,
+      // in case this mission-non-critical fetch takes a long time.
+      useFetch("/api/versions", {
+        onResponse: ({ response }) => {
+          const data = response._data;
+          if (data.daedalusModel) {
+            this.versions = data as VersionData;
+          }
+        },
+        lazy: true, // Allows the user to navigate to the current page while this fetch is still pending.
+      }) as { data: Ref<VersionData> };
     },
     setScreenSize(bool: boolean): void {
       this.largeScreen = bool;

--- a/tests/unit/components/SideBar.spec.ts
+++ b/tests/unit/components/SideBar.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
-import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
 import type { VueWrapper } from "@vue/test-utils";
 import { mockPinia } from "@/tests/unit/mocks/mockPinia";
@@ -14,18 +14,12 @@ const mockCSidebarPageloadBehavior = async (coreuiSidebar: VueWrapper) => {
   coreuiSidebar.vm.$emit("hide");
 };
 
-describe("sidebar", () => {
-  registerEndpoint("/api/versions", () => {
-    return {
-      daedalusModel: "1.2.3",
-      daedalusApi: "4.5.6",
-      daedalusWebApp: "7.8.9",
-    };
-  });
+const mockedVersions = { daedalusModel: "1.2.3", daedalusApi: "4.5.6", daedalusWebApp: "7.8.9" };
 
+describe("sidebar", () => {
   describe('when the "visible" prop is initialized as false', () => {
     describe("on smaller devices", () => {
-      const plugins = [mockPinia({ largeScreen: false })];
+      const plugins = [mockPinia({ largeScreen: false, versions: mockedVersions })];
 
       it('starts as hidden, and can be opened by setting "visible" prop', async () => {
         const component = await mountSuspended(SideBar, {
@@ -69,7 +63,7 @@ describe("sidebar", () => {
     });
 
     describe("on larger devices", () => {
-      const plugins = [mockPinia({ largeScreen: true })];
+      const plugins = [mockPinia({ largeScreen: true, versions: mockedVersions })];
 
       it("starts as shown", async () => {
         const component = await mountSuspended(SideBar, {

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -8,6 +8,20 @@ const stubs = {
 };
 
 describe("default layout", () => {
+  it("adds a resize event listener on mount and removes it on unmount", async () => {
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const component = await mountSuspended(DefaultLayout, { global: { stubs } });
+    expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+
+    component.unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
   describe("on smaller devices", () => {
     beforeAll(() => {
       vi.stubGlobal("innerWidth", 500);
@@ -22,20 +36,6 @@ describe("default layout", () => {
       const header = component.findComponent({ name: "AppHeader" });
       await header.vm.$emit("toggleSidebarVisibility");
       expect(sidebar.props("visible")).toBe(true);
-    });
-
-    it("adds a resize event listener on mount and removes it on unmount", async () => {
-      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
-      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-
-      const component = await mountSuspended(DefaultLayout, { global: { stubs } });
-      expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-
-      component.unmount();
-      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-
-      addEventListenerSpy.mockRestore();
-      removeEventListenerSpy.mockRestore();
     });
 
     afterAll(() => {

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
+import { registerEndpoint } from "@nuxt/test-utils/runtime";
 import { useAppStore } from "@/stores/appStore";
 
 describe("app store", () => {
@@ -7,20 +8,48 @@ describe("app store", () => {
     setActivePinia(createPinia());
   });
 
+  registerEndpoint("/api/versions", () => {
+    return {
+      daedalusModel: "1.2.3",
+      daedalusApi: "4.5.6",
+      daedalusWebApp: "7.8.9",
+    };
+  });
+
   describe("actions", () => {
     it("initialises correctly", async () => {
       const store = useAppStore();
       expect(store.largeScreen).toBe(true);
-      store.initializeAppState();
+      expect(store.versions).toBeUndefined();
+      await store.initializeAppState();
+
       expect(store.largeScreen).toBe(true);
+      expect(store.versions).toEqual({
+        daedalusModel: "1.2.3",
+        daedalusApi: "4.5.6",
+        daedalusWebApp: "7.8.9",
+      });
     });
 
     it("can update and retrieve the screen size", async () => {
       const store = useAppStore();
+      await store.initializeAppState();
       const { screenIsLarge } = storeToRefs(store);
 
       store.setScreenSize(false);
       expect(screenIsLarge.value).toBe(false);
+    });
+
+    it("can retrieve the version numbers", async () => {
+      const store = useAppStore();
+      await store.initializeAppState();
+      const { getVersions } = storeToRefs(store);
+
+      expect(getVersions.value).toEqual({
+        daedalusModel: "1.2.3",
+        daedalusApi: "4.5.6",
+        daedalusWebApp: "7.8.9",
+      });
     });
   });
 });

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/vue";
 import { createPinia, setActivePinia } from "pinia";
 import { registerEndpoint } from "@nuxt/test-utils/runtime";
 import { useAppStore } from "@/stores/appStore";
@@ -21,19 +22,21 @@ describe("app store", () => {
       const store = useAppStore();
       expect(store.largeScreen).toBe(true);
       expect(store.versions).toBeUndefined();
-      await store.initializeAppState();
+      store.initializeAppState();
 
       expect(store.largeScreen).toBe(true);
-      expect(store.versions).toEqual({
-        daedalusModel: "1.2.3",
-        daedalusApi: "4.5.6",
-        daedalusWebApp: "7.8.9",
+      await waitFor(() => {
+        expect(store.versions).toEqual({
+          daedalusModel: "1.2.3",
+          daedalusApi: "4.5.6",
+          daedalusWebApp: "7.8.9",
+        });
       });
     });
 
     it("can update and retrieve the screen size", async () => {
       const store = useAppStore();
-      await store.initializeAppState();
+      store.initializeAppState();
       const { screenIsLarge } = storeToRefs(store);
 
       store.setScreenSize(false);
@@ -42,13 +45,15 @@ describe("app store", () => {
 
     it("can retrieve the version numbers", async () => {
       const store = useAppStore();
-      await store.initializeAppState();
+      store.initializeAppState();
       const { getVersions } = storeToRefs(store);
 
-      expect(getVersions.value).toEqual({
-        daedalusModel: "1.2.3",
-        daedalusApi: "4.5.6",
-        daedalusWebApp: "7.8.9",
+      await waitFor(() => {
+        expect(getVersions.value).toEqual({
+          daedalusModel: "1.2.3",
+          daedalusApi: "4.5.6",
+          daedalusWebApp: "7.8.9",
+        });
       });
     });
   });

--- a/types/storeTypes.ts
+++ b/types/storeTypes.ts
@@ -1,3 +1,6 @@
+import type { VersionData } from "@/types/apiResponseTypes";
+
 export interface AppState {
   largeScreen: boolean
+  versions: VersionData | undefined
 };


### PR DESCRIPTION
Very piecemeal, I hope you like tiny PRs! But some large thinking about it...

For the case of version data, we don't need to make everything (page rendering, loading...) wait around for the R API to respond. So I've configured this initialization of store data to be very lazy. By that I mean it's supposed not to block the execution of JS (I avoid using 'await') or slow down client-side rendering.

That said, I can see that the version data is included in the version of the page that is rendered server-side (by using 'inspect source' in a browser or 'payload' in Nuxt devtools). That implies to me that, by the time the server finishes rendering the page, the fetch has already resolved (the R API responded quickly enough), and there was time enough for this data to be included in the render.

I thought the lazyness would add value in situations where the R API responds slowly for whatever reason, during the server-side render. In that case, the lazyness would mean the server renders a page that doesn't include any version data. I believe the client, on receiving this, would retry the request, and (since we set 'lazy: true' - [docs here](https://nuxt.com/docs/api/composables/use-fetch#params)) would not slow down any page navigation in order to do so.

That's the theory, anyway, but when I set 'timeout: 10000' in server/utils/rApi.ts (i.e. tell the web app to give up on the R API after 10 seconds), and simulate infinitely long response times from the R API using Mockoon, the page does in fact hang for 10 seconds on refresh. As if the `lazy: true` option is being ignored. (Was using a page that doesn't make any metadata requests to isolate the test case.) Then I thought, is it because I'm doing a manual refresh rather than following a link? That's a possible reading of the documentation. But `lazy: true` doesn't seem to be necessary / make a difference with that, either, in the sense that whether or not I use that option, _following a link_ always takes me nicely to the next page, doing the desired fallback of omitting the version data in the sidebar, as I would have hoped would happen on the initial load of the website. (Side note - to do that test of the lazy:true option required moving the sidebar component from the default layout into the page being loaded, otherwise Nuxt just re-uses the existing layout when you navigate to the next page, skipping the request for version data.) 

So I don't have confidence that the commit that tries to introduce lazyness is having any of the desired effect.

So I'm not sure whether to keep the second commit in, in case it does provide value that I haven't been able to prove, or to revert to the first commit, so that at least we can be sure we know what's going on / we don't have any code that only illusorily does what we think it does.

I'm leaning to just revert to the first commit, so that we always remain abreast of how things work, but interested in your thoughts.