### PR TITLE
Use pinia store for version data and metadata

### DIFF
--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -77,7 +77,7 @@
       </CButton>
     </CForm>
     <CAlert v-else-if="appStore.metadataFetchStatus === 'error'" color="warning">
-      Failed to retrieve metadata from R API. {{ appStore.metadataFetchError }}
+      Failed to initialise. {{ appStore.metadataFetchError }}
     </CAlert>
     <CSpinner v-else-if="appStore.metadataFetchStatus === 'pending'" />
   </div>

--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -68,11 +68,11 @@
         color="primary"
         :size="appStore.largeScreen ? 'lg' : undefined"
         type="submit"
-        :disabled="formSubmitting || props.metadataFetchStatus === 'error'"
+        :disabled="formSubmitting || appStore.metadataFetchStatus === 'error'"
         @click="submitForm"
       >
         Run
-        <CSpinner v-if="formSubmitting && props.metadataFetchStatus !== 'error'" size="sm" class="ms-1" />
+        <CSpinner v-if="formSubmitting && appStore.metadataFetchStatus !== 'error'" size="sm" class="ms-1" />
         <CIcon v-else icon="cilArrowRight" />
       </CButton>
     </CForm>

--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-show="pageMounted">
+  <div>
     <CForm
       v-if="props.metadata && formData"
       class="inputs"
@@ -109,7 +109,6 @@ const formData = ref(
 
 const appStore = useAppStore();
 const navigateToData = ref("");
-const pageMounted = ref(false);
 
 const optionsAreTerse = (parameter: Parameter) => {
   const eachOptionIsASingleWord = parameter.options.every((option) => {
@@ -148,10 +147,6 @@ const submitForm = async () => {
     await navigateTo(navigateToData.value);
   };
 };
-
-onMounted(() => {
-  pageMounted.value = true;
-});
 </script>
 
 <style lang="scss">

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -57,21 +57,19 @@
 
 <script lang="ts" setup>
 import { CIcon } from "@coreui/icons-vue";
-import type { VersionData } from "@/types/apiResponseTypes";
 
-const { data: versionData } = useFetch("/api/versions") as { data: Ref<VersionData> };
+const appStore = useAppStore();
 
 const versionTooltipContent = computed(() => {
-  if (versionData.value) {
-    return `Model version: ${versionData.value.daedalusModel} \nR API version: ${versionData.value.daedalusApi} \nWeb app version: ${versionData.value.daedalusWebApp}`;
+  const vers = appStore.versions;
+  if (vers) {
+    return `Model version: ${vers.daedalusModel} \nR API version: ${vers.daedalusApi} \nWeb app version: ${vers.daedalusWebApp}`;
   } else {
     return undefined;
   }
 });
 
 const visible = defineModel("visible", { type: Boolean, required: true });
-
-const appStore = useAppStore();
 
 const resetSidebarPerScreenSize = () => {
   visible.value = appStore.largeScreen;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,7 +25,7 @@ function handleToggleSidebarVisibility() {
 }
 
 const appStore = useAppStore();
-await appStore.initializeAppState();
+appStore.initializeAppState();
 
 const setScreenSize = () => {
   const breakpoint = 992; // CoreUI's "lg" breakpoint

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -35,6 +35,8 @@ const setScreenSize = () => {
   }
 };
 
+appStore.loadMetadata();
+
 onMounted(() => {
   setScreenSize();
   appStore.loadVersionData();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,7 +25,6 @@ function handleToggleSidebarVisibility() {
 }
 
 const appStore = useAppStore();
-appStore.initializeAppState();
 
 const setScreenSize = () => {
   const breakpoint = 992; // CoreUI's "lg" breakpoint
@@ -38,6 +37,7 @@ const setScreenSize = () => {
 
 onMounted(() => {
   setScreenSize();
+  appStore.loadVersionData();
   window.addEventListener("resize", setScreenSize);
 });
 onBeforeUnmount(() => {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -24,11 +24,10 @@ function handleToggleSidebarVisibility() {
   sidebarVisible.value = !sidebarVisible.value;
 }
 
-const appStore = useAppStore(useNuxtApp().$pinia);
+const appStore = useAppStore();
+await appStore.initializeAppState();
 
 const setScreenSize = () => {
-  // As this function uses window, it can only be run client-side, so we have to pass the $pinia instance
-  // to the useAppStore function: https://pinia.vuejs.org/ssr/nuxt.html#Awaiting-for-actions-in-pages
   const breakpoint = 992; // CoreUI's "lg" breakpoint
   if (window.innerWidth < breakpoint) {
     appStore.largeScreen = false;

--- a/pages/scenarios/index.vue
+++ b/pages/scenarios/index.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts" setup>
 // https://nuxt.com/docs/getting-started/data-fetching
-const { data: scenarios } = await useFetch("/api/scenarios");
+const { data: scenarios } = useFetch("/api/scenarios");
 </script>
 
 <style lang="scss" scoped>

--- a/pages/scenarios/new.vue
+++ b/pages/scenarios/new.vue
@@ -3,35 +3,12 @@
     <div class="overlay">
       <h3>Simulate a new scenario</h3>
       <p>Select the parameters for your next scenario.</p>
-      <ParameterForm
-        :metadata="metadata"
-        :metadata-fetch-status="metadataFetchStatus"
-        :metadata-fetch-error="metadataFetchError"
-      />
+      <ParameterForm />
     </div>
-    <p>{{ globeParameter?.id }} globe select to go here in future PR</p>
   </div>
 </template>
 
 <script lang="ts" setup>
-import type { FetchError } from "ofetch";
-import type { AsyncDataRequestStatus } from "#app";
-import { type Metadata, ParameterType } from "@/types/apiResponseTypes";
-
-const { data: metadata, status: metadataFetchStatus, error: metadataFetchError } = useFetch("/api/metadata") as {
-  data: Ref<Metadata>
-  status: Ref<AsyncDataRequestStatus>
-  error: Ref<FetchError | null>
-};
-
-const globeParameter = computed(() => {
-  if (metadata.value) {
-    return metadata.value.parameters.filter(parameter => parameter.parameterType === ParameterType.GlobeSelect)[0];
-  } else {
-    return undefined;
-  }
-});
-
 definePageMeta({
   hideBreadcrumbs: true,
 });

--- a/server/utils/rApi.ts
+++ b/server/utils/rApi.ts
@@ -28,7 +28,7 @@ export const fetchRApi = async <T extends object>(
   const response = await $fetch<RApiResponse<T>>(`${endpoint}`, {
     ...options,
     baseURL: config.rApiBase,
-    timeout: 1000, // Prevent hanging if no response
+    timeout: 200, // Prevent hanging if no response
     async onResponse({ response }) {
       statusText = response.statusText;
       statusCode = response.status;

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -1,20 +1,38 @@
 import { defineStore } from "pinia";
+import type { FetchError } from "ofetch";
+import type { AsyncDataRequestStatus } from "#app";
 import type { AppState } from "@/types/storeTypes";
-import type { VersionData } from "@/types/apiResponseTypes";
+import type { Metadata, VersionData } from "@/types/apiResponseTypes";
+import { TypeOfParameter } from "@/types/parameterTypes";
 
 export const useAppStore = defineStore("app", {
   state: (): AppState => ({
     largeScreen: true,
     versions: undefined,
+    metadata: undefined,
+    metadataFetchError: undefined,
+    metadataFetchStatus: undefined,
   }),
+  getters: {
+    globeParameter: state => state.metadata?.parameters.find(param => param.parameterType === TypeOfParameter.GlobeSelect),
+  },
   actions: {
+    async loadMetadata() {
+      const { data: metadata, status: metadataFetchStatus, error: metadataFetchError } = await useFetch("/api/metadata") as {
+        data: Ref<Metadata>
+        status: Ref<AsyncDataRequestStatus>
+        error: Ref<FetchError | undefined>
+      };
+      this.metadata = metadata.value;
+      this.metadataFetchStatus = metadataFetchStatus.value;
+      this.metadataFetchError = metadataFetchError.value;
+    },
     // This function is designed to be called e.g. in onMounted lifecycle hooks, not
     // setup scripts (hence the use of $fetch rather than useFetch), since version data
     // does not need to be immediately available as soon as the page loads. We therefore
     // don't need to make the render of the page wait for this data to be fetched.
+    // Just in case this mission-non-critical fetch takes a long time.
     loadVersionData(): void {
-      // No need for 'await' here - would needlessly block other execution.
-      // Just in case this mission-non-critical fetch takes a long time.
       $fetch("/api/versions", {
         onResponse: ({ response }) => {
           const data = response._data;

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -1,8 +1,16 @@
 import { defineStore } from "pinia";
 import type { AppState } from "@/types/storeTypes";
+import type { VersionData } from "@/types/apiResponseTypes";
 
 export const useAppStore = defineStore("app", {
   state: (): AppState => ({
     largeScreen: true,
+    versions: undefined,
   }),
+  actions: {
+    async initializeAppState() {
+      const { data: versionData } = await useFetch("/api/versions", { timeout: 100 }) as { data: Ref<VersionData> };
+      this.versions = versionData.value;
+    },
+  },
 });

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -8,20 +8,21 @@ export const useAppStore = defineStore("app", {
     versions: undefined,
   }),
   actions: {
-    initializeAppState(): void {
-      this.largeScreen = true;
-
-      // Avoid using 'await', which would block the rest of the code including the component setup function,
-      // in case this mission-non-critical fetch takes a long time.
-      useFetch("/api/versions", {
+    // This function is designed to be called e.g. in onMounted lifecycle hooks, not
+    // setup scripts (hence the use of $fetch rather than useFetch), since version data
+    // does not need to be immediately available as soon as the page loads. We therefore
+    // don't need to make the render of the page wait for this data to be fetched.
+    loadVersionData(): void {
+      // No need for 'await' here - would needlessly block other execution.
+      // Just in case this mission-non-critical fetch takes a long time.
+      $fetch("/api/versions", {
         onResponse: ({ response }) => {
           const data = response._data;
           if (data.daedalusModel) {
             this.versions = data as VersionData;
           }
         },
-        lazy: true, // Allows the user to navigate to the current page while this fetch is still pending.
-      }) as { data: Ref<VersionData> };
+      });
     },
   },
 });

--- a/tests/e2e/runAnalysis.spec.ts
+++ b/tests/e2e/runAnalysis.spec.ts
@@ -10,7 +10,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.waitForURL(`${baseURL}/scenarios/new`);
 
   await expect(page.getByText("Simulate a new scenario")).toBeVisible();
-  await expect(page.getByRole("form")).toBeVisible();
+
+  // Reduce flakeyness of tests by waiting for evidence that the page has mounted.
+  await expect(page.getByTitle(/Web app version: 0.0.1/)).toHaveCount(1);
 
   await page.selectOption('select[id="pathogen"]', { label: "Influenza 1957" });
   await page.selectOption('select[id="response"]', { label: "Elimination" });

--- a/tests/unit/components/ParameterForm.spec.ts
+++ b/tests/unit/components/ParameterForm.spec.ts
@@ -168,7 +168,7 @@ describe("parameter form", () => {
     });
 
     expect(component.findComponent({ name: "CAlert" }).exists()).toBe(true);
-    expect(component.text()).toContain("Failed to retrieve metadata from R API.");
+    expect(component.text()).toContain("Failed to initialise.");
     expect(component.text()).toContain("There was a bee-related issue.");
   });
 

--- a/tests/unit/components/ParameterForm.spec.ts
+++ b/tests/unit/components/ParameterForm.spec.ts
@@ -5,6 +5,7 @@ import { readBody } from "h3";
 import { flushPromises } from "@vue/test-utils";
 import { waitFor } from "@testing-library/vue";
 
+import { mockPinia } from "@/tests/unit/mocks/mockPinia";
 import type { Metadata } from "@/types/apiResponseTypes";
 import ParameterForm from "@/components/ParameterForm.vue";
 
@@ -58,8 +59,13 @@ const metadata = { modelVersion: "0.0.0", parameters: [...selectParameters, glob
 describe("parameter form", () => {
   it("renders the correct parameter labels, inputs, options, and default values", async () => {
     const component = await mountSuspended(ParameterForm, {
-      props: { metadata, metadataFetchStatus: "success", metadataFetchError: null },
-      global: { stubs },
+      global: {
+        stubs,
+        plugins: [mockPinia({
+          metadata,
+          metadataFetchStatus: "success",
+        })],
+      },
     });
 
     expect(component.text()).toContain("Region");
@@ -122,8 +128,13 @@ describe("parameter form", () => {
     });
 
     const component = await mountSuspended(ParameterForm, {
-      props: { metadata, metadataFetchStatus: "success", metadataFetchError: null },
-      global: { stubs },
+      global: {
+        stubs,
+        plugins: [mockPinia({
+          metadata,
+          metadataFetchStatus: "success",
+        })],
+      },
     });
 
     const buttonEl = component.find("button[type='submit']");
@@ -146,8 +157,14 @@ describe("parameter form", () => {
     const error = new FetchError("There was a bee-related issue.");
 
     const component = await mountSuspended(ParameterForm, {
-      props: { metadata: undefined, metadataFetchStatus: "error", metadataFetchError: error },
-      global: { stubs },
+      global: {
+        stubs,
+        plugins: [mockPinia({
+          metadata: undefined,
+          metadataFetchStatus: "error",
+          metadataFetchError: error,
+        })],
+      },
     });
 
     expect(component.findComponent({ name: "CAlert" }).exists()).toBe(true);
@@ -157,8 +174,13 @@ describe("parameter form", () => {
 
   it("displays CSpinner when metadataFetchStatus is 'pending'", async () => {
     const component = await mountSuspended(ParameterForm, {
-      props: { metadata: undefined, metadataFetchStatus: "pending", metadataFetchError: null },
-      global: { stubs },
+      global: {
+        stubs,
+        plugins: [mockPinia({
+          metadata: undefined,
+          metadataFetchStatus: "pending",
+        })],
+      },
     });
 
     expect(component.findComponent({ name: "CSpinner" }).exists()).toBe(true);

--- a/tests/unit/components/SideBar.spec.ts
+++ b/tests/unit/components/SideBar.spec.ts
@@ -44,11 +44,6 @@ describe("sidebar", () => {
           global: { stubs, plugins },
         });
 
-        const coreuiSidebar = component.findComponent({ name: "CSidebar" });
-        await mockCSidebarPageloadBehavior(coreuiSidebar);
-
-        await component.setProps({ visible: true });
-
         await waitFor(() => {
           const logoTitleAttribute = component.find(`[data-testid="logo"]`).attributes().title;
           expect(logoTitleAttribute).toContain("Model version: 1.2.3");

--- a/tests/unit/components/SideBar.spec.ts
+++ b/tests/unit/components/SideBar.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
-import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
 import type { VueWrapper } from "@vue/test-utils";
 import { mockPinia } from "@/tests/unit/mocks/mockPinia";
@@ -14,18 +14,12 @@ const mockCSidebarPageloadBehavior = async (coreuiSidebar: VueWrapper) => {
   coreuiSidebar.vm.$emit("hide");
 };
 
-describe("sidebar", () => {
-  registerEndpoint("/api/versions", () => {
-    return {
-      daedalusModel: "1.2.3",
-      daedalusApi: "4.5.6",
-      daedalusWebApp: "7.8.9",
-    };
-  });
+const mockedVersions = { daedalusModel: "1.2.3", daedalusApi: "4.5.6", daedalusWebApp: "7.8.9" };
 
+describe("sidebar", () => {
   describe('when the "visible" prop is initialized as false', () => {
     describe("on smaller devices", () => {
-      const plugins = [mockPinia({ largeScreen: false })];
+      const plugins = [mockPinia({ largeScreen: false, versions: mockedVersions })];
 
       it('starts as hidden, and can be opened by setting "visible" prop', async () => {
         const component = await mountSuspended(SideBar, {
@@ -69,7 +63,7 @@ describe("sidebar", () => {
     });
 
     describe("on larger devices", () => {
-      const plugins = [mockPinia({ largeScreen: true })];
+      const plugins = [mockPinia({ largeScreen: true, versions: mockedVersions })];
 
       it("starts as shown", async () => {
         const component = await mountSuspended(SideBar, {

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
-
 import DefaultLayout from "@/layouts/default.vue";
 
 const stubs = {

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -1,11 +1,20 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
+import { waitFor } from "@testing-library/vue";
 
 import DefaultLayout from "@/layouts/default.vue";
 
 const stubs = {
   CIcon: true,
 };
+
+registerEndpoint("/api/versions", () => {
+  return {
+    daedalusModel: "1.2.3",
+    daedalusApi: "4.5.6",
+    daedalusWebApp: "7.8.9",
+  };
+});
 
 describe("default layout", () => {
   it("adds a resize event listener on mount and removes it on unmount", async () => {
@@ -20,6 +29,17 @@ describe("default layout", () => {
 
     addEventListenerSpy.mockRestore();
     removeEventListenerSpy.mockRestore();
+  });
+
+  it("includes information about the version numbers", async () => {
+    const component = await mountSuspended(DefaultLayout, { global: { stubs } });
+
+    await waitFor(() => {
+      const logoTitleAttribute = component.find(`[data-testid="logo"]`).attributes().title;
+      expect(logoTitleAttribute).toContain("Model version: 1.2.3");
+      expect(logoTitleAttribute).toContain("R API version: 4.5.6");
+      expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
+    });
   });
 
   describe("on smaller devices", () => {

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -8,6 +8,20 @@ const stubs = {
 };
 
 describe("default layout", () => {
+  it("adds a resize event listener on mount and removes it on unmount", async () => {
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const component = await mountSuspended(DefaultLayout, { global: { stubs } });
+    expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+
+    component.unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
   describe("on smaller devices", () => {
     beforeAll(() => {
       vi.stubGlobal("innerWidth", 500);
@@ -22,20 +36,6 @@ describe("default layout", () => {
       const header = component.findComponent({ name: "AppHeader" });
       await header.vm.$emit("toggleSidebarVisibility");
       expect(sidebar.props("visible")).toBe(true);
-    });
-
-    it("adds a resize event listener on mount and removes it on unmount", async () => {
-      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
-      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-
-      const component = await mountSuspended(DefaultLayout, { global: { stubs } });
-      expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-
-      component.unmount();
-      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-
-      addEventListenerSpy.mockRestore();
-      removeEventListenerSpy.mockRestore();
     });
 
     afterAll(() => {

--- a/tests/unit/mocks/mockPinia.ts
+++ b/tests/unit/mocks/mockPinia.ts
@@ -6,6 +6,10 @@ export const mockPinia = (appState: Partial<AppState> = {}) => {
   const initialState = {
     app: {
       largeScreen: true,
+      versions: undefined,
+      metadata: undefined,
+      metadataFetchError: undefined,
+      metadataFetchStatus: undefined,
       ...appState,
     },
   };

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -17,10 +17,26 @@ describe("app store", () => {
     };
   });
 
+  registerEndpoint("/api/metadata", () => {
+    return {
+      parameters: [
+        { id: "country", parameterType: "globeSelect" },
+        { id: "settings", parameterType: "select" },
+      ],
+      results: {
+        costs: [
+          { id: "total", label: "Total" },
+        ],
+      },
+      modelVersion: "1.2.3",
+    };
+  });
+
   describe("actions", () => {
     it("initialises correctly", async () => {
       const store = useAppStore();
       expect(store.versions).toBeUndefined();
+      expect(store.metadata).toBeUndefined();
       expect(store.largeScreen).toBe(true);
     });
 
@@ -28,13 +44,41 @@ describe("app store", () => {
       const store = useAppStore();
       store.loadVersionData();
 
-      // The fetch should eventually complete, and the version numbers should be updated.
       await waitFor(() => {
         expect(store.versions).toEqual({
           daedalusModel: "1.2.3",
           daedalusApi: "4.5.6",
           daedalusWebApp: "7.8.9",
         });
+      });
+    });
+
+    it("can retrieve the metadata", async () => {
+      const store = useAppStore();
+      await store.loadMetadata();
+
+      await waitFor(() => {
+        expect(store.metadata).toEqual({
+          parameters: [
+            { id: "country", parameterType: "globeSelect" },
+            { id: "settings", parameterType: "select" },
+          ],
+          results: {
+            costs: [
+              { id: "total", label: "Total" },
+            ],
+          },
+          modelVersion: "1.2.3",
+        });
+      });
+    });
+
+    it("can get the globe parameter", async () => {
+      const store = useAppStore();
+      await store.loadMetadata();
+
+      await waitFor(() => {
+        expect(store.globeParameter).toEqual({ id: "country", parameterType: "globeSelect" });
       });
     });
   });

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
+import { registerEndpoint } from "@nuxt/test-utils/runtime";
 import { useAppStore } from "@/stores/appStore";
 
 describe("app store", () => {
@@ -7,10 +8,27 @@ describe("app store", () => {
     setActivePinia(createPinia());
   });
 
+  registerEndpoint("/api/versions", () => {
+    return {
+      daedalusModel: "1.2.3",
+      daedalusApi: "4.5.6",
+      daedalusWebApp: "7.8.9",
+    };
+  });
+
   describe("actions", () => {
     it("initialises correctly", async () => {
       const store = useAppStore();
       expect(store.largeScreen).toBe(true);
+      expect(store.versions).toBeUndefined();
+      await store.initializeAppState();
+
+      expect(store.largeScreen).toBe(true);
+      expect(store.versions).toEqual({
+        daedalusModel: "1.2.3",
+        daedalusApi: "4.5.6",
+        daedalusWebApp: "7.8.9",
+      });
     });
   });
 });

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/vue";
 import { createPinia, setActivePinia } from "pinia";
 import { registerEndpoint } from "@nuxt/test-utils/runtime";
 import { useAppStore } from "@/stores/appStore";
@@ -21,13 +22,15 @@ describe("app store", () => {
       const store = useAppStore();
       expect(store.largeScreen).toBe(true);
       expect(store.versions).toBeUndefined();
-      await store.initializeAppState();
+      store.initializeAppState();
 
       expect(store.largeScreen).toBe(true);
-      expect(store.versions).toEqual({
-        daedalusModel: "1.2.3",
-        daedalusApi: "4.5.6",
-        daedalusWebApp: "7.8.9",
+      await waitFor(() => {
+        expect(store.versions).toEqual({
+          daedalusModel: "1.2.3",
+          daedalusApi: "4.5.6",
+          daedalusWebApp: "7.8.9",
+        });
       });
     });
   });

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -20,11 +20,15 @@ describe("app store", () => {
   describe("actions", () => {
     it("initialises correctly", async () => {
       const store = useAppStore();
-      expect(store.largeScreen).toBe(true);
       expect(store.versions).toBeUndefined();
-      store.initializeAppState();
-
       expect(store.largeScreen).toBe(true);
+    });
+
+    it("can retrieve the version numbers", async () => {
+      const store = useAppStore();
+      store.loadVersionData();
+
+      // The fetch should eventually complete, and the version numbers should be updated.
       await waitFor(() => {
         expect(store.versions).toEqual({
           daedalusModel: "1.2.3",

--- a/types/apiResponseTypes.ts
+++ b/types/apiResponseTypes.ts
@@ -1,4 +1,5 @@
 // Types for responses from our API endpoints.
+import type { Parameter } from "./parameterTypes";
 
 export interface ApiError {
   error: string
@@ -21,27 +22,15 @@ export interface VersionData {
 export interface VersionDataResponse extends ApiResponse<VersionData> { }
 
 // Metadata
-export interface ParameterOption {
-  id: string
+interface DisplayInfo {
   label: string
-}
-
-export enum ParameterType {
-  Select = "select",
-  GlobeSelect = "globeSelect",
-  Numeric = "numeric",
-}
-export interface Parameter {
-  id: string
-  label: string
-  parameterType: ParameterType
-  defaultOption: string | null
-  ordered: boolean
-  options: Array<ParameterOption>
+  value: number
+  description: string | null
 }
 export interface Metadata {
   modelVersion: string
   parameters: Array<Parameter>
+  results: Record<string, Array<DisplayInfo>>
 }
 
 export interface MetadataResponse extends ApiResponse<Metadata> { }

--- a/types/parameterTypes.ts
+++ b/types/parameterTypes.ts
@@ -1,0 +1,32 @@
+export interface ParameterOption {
+  id: string
+  label: string
+}
+
+export enum TypeOfParameter {
+  Select = "select",
+  GlobeSelect = "globeSelect",
+  Numeric = "numeric",
+}
+
+interface ValueData {
+  min: number
+  default: number
+  max: number
+}
+
+interface UpdateNumericFrom {
+  parameterId: string
+  values: Array<Record<string, ValueData>>
+}
+
+export interface Parameter {
+  id: string
+  label: string
+  parameterType: TypeOfParameter
+  defaultOption: string | null
+  ordered: boolean
+  options: Array<ParameterOption>
+  step: number | null
+  updateNumericFrom: UpdateNumericFrom | null
+}

--- a/types/parameterTypes.ts
+++ b/types/parameterTypes.ts
@@ -17,7 +17,7 @@ interface ValueData {
 
 interface UpdateNumericFrom {
   parameterId: string
-  values: Array<Record<string, ValueData>>
+  values: Record<string, ValueData>
 }
 
 export interface Parameter {

--- a/types/storeTypes.ts
+++ b/types/storeTypes.ts
@@ -1,3 +1,6 @@
+import type { VersionData } from "@/types/apiResponseTypes";
+
 export interface AppState {
   largeScreen: boolean
+  versions: VersionData | undefined
 };

--- a/types/storeTypes.ts
+++ b/types/storeTypes.ts
@@ -1,6 +1,11 @@
-import type { VersionData } from "@/types/apiResponseTypes";
+import type { FetchError } from "ofetch";
+import type { AsyncDataRequestStatus } from "#app";
+import type { Metadata, VersionData } from "@/types/apiResponseTypes";
 
 export interface AppState {
   largeScreen: boolean
   versions: VersionData | undefined
+  metadata: Metadata | undefined
+  metadataFetchError: FetchError | undefined
+  metadataFetchStatus: AsyncDataRequestStatus | undefined
 };


### PR DESCRIPTION
A refactor moving these two kinds of requests into the app store. They'll only be requested by the layout component, and so they are expected to only be requested once per site visit (unless the user goes around doing manual page refreshes), and otherwise persist in the store between 'page loads'. (Navigation using NuxtLinks and navigateTo doesn't trigger a full page request, just a request for the necessary components.)

I wanted the loading of version data not to slow down any part of the process of getting the page to be in front of the user. Through a few different commits and a [closed PR](https://github.com/jameel-institute/daedalus-web-app/pull/26) I eventually settled on the solution of making the request in an `onMounted` hook.