### PR TITLE
jidea-76 run redis and api worker in dependencies

### DIFF
--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -97,7 +97,7 @@ const props = defineProps<{
 const formData = ref(
   // Create a new object with keys set to the id values of the metadata.parameters array of objects, and all values set to default values.
   props.metadata?.parameters.reduce((acc, { id, defaultOption, options }) => {
-    acc[id] = defaultOption || options[0].id;
+    acc[id] = defaultOption || (options && options[0].id) || "";
     return acc;
   }, {} as { [key: string]: string | number }),
 );

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -49,7 +49,7 @@ VOLUME=daedalus-results
 docker network create $NETWORK
 docker network connect daedalus daedalus-web-app-db
 
-docker volume create VOLUME
+docker volume create $VOLUME
 
 # Pull and run the R API image
 # TODO: reset this to latest when the rrq branch of the api is merged

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -43,10 +43,51 @@ fi
 
 docker exec daedalus-web-app-db wait-for-db
 
-docker network create daedalus
+NETWORK=daedalus
+VOLUME=daedalus-results
+
+docker network create $NETWORK
 docker network connect daedalus daedalus-web-app-db
 
+docker volume create VOLUME
+
 # Pull and run the R API image
-R_API_IMAGE='mrcide/daedalus.api:latest'
+# TODO: reset this to latest when the rrq branch of the api is merged
+R_API_IMAGE='mrcide/daedalus.api:jidea-74'
 docker pull $R_API_IMAGE # There will be a 'latest' tag: https://github.com/jameel-institute/daedalus.api/pull/2#issuecomment-2252491603
-docker run -d --name daedalus-api --rm --network=daedalus -p 8001:8001 $R_API_IMAGE
+
+QUEUE_ID=daedalus-api-queue-$(uuidgen)
+
+docker run --rm -d \
+  -p 127.0.0.1:6379:6379 \
+  --name=daedalus-redis \
+  --network=$NETWORK \
+  redis
+
+# Ephemeral container for one-time queue configuration
+docker run --rm \
+  --network=$NETWORK \
+  --env=DAEDALUS_QUEUE_ID=$QUEUE_ID \
+  --env=REDIS_CONTAINER_NAME=daedalus-redis \
+  --entrypoint="/usr/local/bin/daedalus.api.configure" \
+  $R_API_IMAGE
+
+docker run --rm -d \
+  -p 8001:8001 \
+  --name=daedalus-api \
+  --network=$NETWORK \
+  -v $VOLUME:/daedalus/results \
+  --env=DAEDALUS_QUEUE_ID=$QUEUE_ID \
+  --env=REDIS_CONTAINER_NAME=daedalus-redis \
+  --entrypoint="/usr/local/bin/daedalus.api" \
+  $R_API_IMAGE
+
+docker run --rm -d \
+  --name=daedalus-api-worker \
+  --network=$NETWORK \
+  -v $VOLUME:/daedalus/results \
+  --env=DAEDALUS_QUEUE_ID=$QUEUE_ID \
+  --env=REDIS_CONTAINER_NAME=daedalus-redis \
+  --entrypoint="/usr/local/bin/daedalus.api.worker" \
+  $R_API_IMAGE
+

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -52,8 +52,7 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-# TODO: reset this to latest when the rrq branch of the api is merged
-R_API_IMAGE='mrcide/daedalus.api:jidea-74'
+R_API_IMAGE='mrcide/daedalus.api:main'
 docker pull $R_API_IMAGE # There will be a 'latest' tag: https://github.com/jameel-institute/daedalus.api/pull/2#issuecomment-2252491603
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/scripts/run-dev-dependencies
+++ b/scripts/run-dev-dependencies
@@ -4,9 +4,12 @@ set -ex
 # From now on, if the user presses Ctrl+C we should teardown gracefully
 function cleanup() {
   set +ex # allow teardown errors
-  docker kill daedalus-web-app-db
-  docker kill daedalus-api
-  docker network remove daedalus
+  docker rm -f daedalus-web-app-db || true
+  docker rm -f daedalus-api || true
+  docker rm -f daedalus-api-worker || true
+  docker rm -f daedalus-redis || true
+  docker volume remove daedalus-results || true
+  docker network remove daedalus || true
   set -e
 }
 

--- a/scripts/run-dev-dependencies
+++ b/scripts/run-dev-dependencies
@@ -4,12 +4,12 @@ set -ex
 # From now on, if the user presses Ctrl+C we should teardown gracefully
 function cleanup() {
   set +ex # allow teardown errors
-  docker rm -f daedalus-web-app-db || true
-  docker rm -f daedalus-api || true
-  docker rm -f daedalus-api-worker || true
-  docker rm -f daedalus-redis || true
-  docker volume remove daedalus-results || true
-  docker network remove daedalus || true
+  docker kill daedalus-web-app-db
+  docker kill daedalus-api
+  docker kill daedalus-api-worker
+  docker kill daedalus-redis
+  docker volume remove daedalus-results
+  docker network remove daedalus
   set -e
 }
 

--- a/tests/e2e/runAnalysis.spec.ts
+++ b/tests/e2e/runAnalysis.spec.ts
@@ -12,7 +12,7 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.selectOption('select[id="pathogen"]', { label: "Influenza 1957" });
   await page.selectOption('select[id="response"]', { label: "Elimination" });
   await page.selectOption('select[id="country"]', { label: "United States" });
-  await page.click('div[aria-label="Advance vaccine investment"] label[for="medium"]');
+  await page.click('div[aria-label="Global vaccine investment"] label[for="medium"]');
 
   await page.click('button:has-text("Run")');
 


### PR DESCRIPTION
This branch includes the additional docker containers required for rrq support in the dependencies scripts. 

Currently targeting [this branch](https://github.com/jameel-institute/daedalus.api/pull/8) of the API. When you're happy with this PR, I'll merge the api branch, and point the scripts here back to main before merging. The deploy tool will be temporarily broken (hopefully very temporarily), but I think it's just going to be more straightforward to target main for all containers when I do the updates there..

The additional containers are:
- redis - rrq uses a redis db to manage the queue
- daedalus api worker - the worker runs the same image as the main api container, but with a different entry point which watches for tasks to run
- daedalus api configure - the queue needs to be configured once before any workers or controllers (task senders) attach. This is done with the same image with yet another entry point. This container is ephemeral and removes itself once the configuration is done. 

You should find that you can run and tear down dependencies using the scripts as normal, but should see additional containers `daedalus-redis` and `daedalus-api-worker` are run. The app should work as normal. 

I had to add a couple of little fixes for issues currently in main as a result of metadata updates 
- form can't assume all parameters will have options
- update to e2e test for new vaccine investment label.  

After this is merged, you'll be getting real responses from the run and status endpoint, but still pre-canned responses from the results endpoint. 