### PR TITLE
Jidea 57 mock navigate to 2

### DIFF
--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -4,7 +4,6 @@
       v-if="props.metadata && formData"
       class="inputs"
       role="form"
-      :data-test-navigate-to="navigateToData"
       @submit.prevent="submitForm"
     >
       <div
@@ -108,7 +107,6 @@ const formData = ref(
 );
 
 const appStore = useAppStore();
-const navigateToData = ref("");
 const pageMounted = ref(false);
 
 const optionsAreTerse = (parameter: Parameter) => {
@@ -144,9 +142,8 @@ const submitForm = async () => {
 
   if (response) {
     const { runId } = response;
-    navigateToData.value = `/scenarios/${runId}`;
-    await navigateTo(navigateToData.value);
-  };
+    await navigateTo(`/scenarios/${runId}`);
+  }
 };
 
 onMounted(() => {


### PR DESCRIPTION
OK, this was very mysterious. The culprit for why this suddently stopped working appears to have been the h3 `readBody` in the test request handler. That was one of the few changes in the relevant files so I tried taking it out and just manually parsing the body, and the mock started working again. ..

I don't really understand why this made a difference - maybe something in that readBody was failing? But I tried debugging it, and it looked like it was getting the runId and doing the navigateTo OK in the component.  Maybe some sort of async issue?

So, yay, but also, huh? 