### PR TITLE
Restyle excel download button

### DIFF
--- a/components/DownloadExcel.vue
+++ b/components/DownloadExcel.vue
@@ -1,10 +1,10 @@
 <template>
-  <div v-show="appStore.currentScenario.parameters" class="d-inline-block ms-2 align-content-center">
+  <div v-show="appStore.currentScenario.parameters" class="d-inline-block ms-auto align-content-center">
     <CSpinner v-if="appStore.downloading" size="sm" class="ms-2" />
     <CTooltip v-else content="Download as Excel file" placement="top">
       <template #toggler="{ togglerId, on }">
         <CButton color="light" :aria-describedby="togglerId" v-on="on" @click="appStore.downloadExcel()">
-          <CIcon icon="cilCloudDownload" size="lg" />
+          <CIcon icon="cilCloudDownload" size="lg" class="text-secondary" />
         </CButton>
       </template>
     </CTooltip>
@@ -25,3 +25,16 @@ watch(() => appStore.downloading, () => {
   alertDismissed.value = false;
 });
 </script>
+
+<style lang="scss" scoped>
+.btn {
+  padding-bottom: 0;
+  height: 100%;
+  border: 1px solid rgba(8, 10, 12, 0.17); // copying from card
+  border-radius: 0.375rem; // copying from card
+
+  &:not(:hover) {
+    background: rgba(255, 255, 255, 0.5);
+  }
+}
+</style>

--- a/pages/scenarios/[runId].vue
+++ b/pages/scenarios/[runId].vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="d-flex flex-wrap mb-4">
+    <div class="d-flex flex-wrap mb-4 gap-3">
       <h1 class="fs-2 mb-0 pt-1">
         Results
       </h1>
@@ -28,7 +28,7 @@
           <ParameterForm :in-modal="true" />
         </CModalBody>
       </CModal>
-      <div v-show="appStore.currentScenario.parameters && appStore.metadata?.parameters" class="card horizontal-card ms-auto">
+      <div v-show="appStore.currentScenario.parameters && appStore.metadata?.parameters" class="card horizontal-card">
         <CRow>
           <div
             v-show="!appStore.largeScreen"


### PR DESCRIPTION
Bringing styling more in line with the neighboring component.

Tested transparency with globe behind

![Screenshot from 2024-10-03 13-24-14](https://github.com/user-attachments/assets/11f3d946-5388-40e8-b213-8bbeb07f0b92)

How it looks on my own branch with a globe in

![image](https://github.com/user-attachments/assets/beaa657c-cdbe-4f92-823c-1c3c3028350b)
