### PR TITLE
Add page title to meta

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -13,6 +13,10 @@ import "~/assets/scss/fonts.scss";
 
 const nuxtApp = useNuxtApp();
 nuxtApp.vueApp.provide("icons", iconsSet);
+
+useHead({
+  title: "DAEDALUS Explore",
+});
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
Very minimal implementation for now - one day we'll make it vary depending on the page.
![image](https://github.com/user-attachments/assets/5f5e2658-232e-48e6-a4b8-b27903e5c368)
