### PR TITLE
Remove unused header nav

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -12,14 +12,6 @@
           <span id="appTitle">DAEDALUS Explore</span>
         </NuxtLink>
       </div>
-      <CHeaderNav class="ms-auto">
-        <CNavItem class="py-1">
-          <div class="vr h-100 mx-1 text-body text-opacity-75" />
-        </CNavItem>
-        <CNavItem id="helpNavLink" href="#">
-          <img id="help" src="~/assets/icons/circleQuestion.svg">
-        </CNavItem>
-      </CHeaderNav>
     </CContainer>
   </CHeader>
 </template>


### PR DESCRIPTION
Remove this thing, which was always a placeholder:

![image](https://github.com/user-attachments/assets/1595116b-3ee9-4867-9e09-ebad982918df)
