### PR TITLE
Fix costs pie bug

### DIFF
--- a/components/CostsPie.client.vue
+++ b/components/CostsPie.client.vue
@@ -178,6 +178,11 @@ const chartInitialOptions = () => {
     exporting: { enabled: false },
     navigation: {
       breadcrumbs: {
+        events: {
+          click() {
+            chart.update({ series: { levels: chartLevelsOptions(false) } });
+          },
+        },
         position: {
           verticalAlign: "bottom",
           align: "center",


### PR DESCRIPTION
Update chart levels settings when navigating via chart breadcrumbs

Ensures that the central circle (the total) is given non-zero area when navigating from drill-down to top-level by use of the breadcrumb link labelled 'Total'.

The link is shown in this screenshot:

![image](https://github.com/user-attachments/assets/fcd3f0bf-bc7a-4c79-b6ff-f957f987ee89)

Before this change it resulted in:

![image](https://github.com/user-attachments/assets/9a992ed3-16e8-49fe-af5b-ea7c1533d56c)

After:

![image](https://github.com/user-attachments/assets/16316cb9-1950-4813-a9b0-0bc0e1cf0cac)
