### PR TITLE
Jodea-170 Move JI logo 

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,16 +1,28 @@
 <template>
   <CHeader class="header-sticky p-0" :class="{ 'shadow-sm': isScrolled }">
-    <CContainer id="headerNavContainer" fluid class="border-bottom mt-1 justify-content-start">
-      <CHeaderToggler class="d-lg-none" @click="toggleSidebarVisibility">
-        <span data-testid="toggle-sidebar-button">
-          <CIcon icon="cilMenu" size="lg" />
-        </span>
-      </CHeaderToggler>
-      <div class="header-brand px-2">
-        <NuxtLink prefetch-on="interaction" to="/" class="nav-link">
-          <CIcon icon="cilGlobeAlt" size="lg" />
-          <span id="appTitle">DAEDALUS Explore</span>
-        </NuxtLink>
+    <CContainer id="headerNavContainer" fluid class="border-bottom mt-1 justify-content-between">
+      <div class="d-flex">
+        <CHeaderToggler class="d-lg-none" @click="$emit('toggleSidebarVisibility')">
+          <span data-testid="toggle-sidebar-button">
+            <CIcon icon="cilMenu" size="lg" />
+          </span>
+        </CHeaderToggler>
+        <div class="header-brand px-2">
+          <NuxtLink prefetch-on="interaction" to="/" class="nav-link">
+            <CIcon icon="cilGlobeAlt" size="lg" />
+            <span id="appTitle">DAEDALUS Explore</span>
+          </NuxtLink>
+        </div>
+      </div>
+      <div class="d-none d-sm-block">
+        <img
+          data-testid="ji-logo-header"
+          style="width: 150px;"
+          class="img-fluid"
+          :title="versionTooltipContent"
+          src="~/assets/img/IMPERIAL_JAMEEL_INSTITUTE_LOCKUP-p-500.png"
+          alt="Imperial College and Community Jameel logo"
+        >
       </div>
     </CContainer>
   </CHeader>
@@ -20,11 +32,12 @@
 import { CIcon } from "@coreui/icons-vue";
 import throttle from "lodash.throttle";
 
-const emit = defineEmits(["toggleSidebarVisibility"]);
-
-function toggleSidebarVisibility() {
-  emit("toggleSidebarVisibility");
-}
+defineProps<{
+  versionTooltipContent: string | undefined
+}>();
+defineEmits<{
+  toggleSidebarVisibility: []
+}>();
 
 // We apply a shadow to the header when the position is scrolled down
 const isScrolled = ref(false);

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -13,12 +13,12 @@
         </NuxtLink>
       </CNavItem>
     </CSidebarNav>
-    <CSidebarHeader class="border-top d-flex">
+    <CSidebarHeader class="border-top d-flex d-sm-none">
       <!-- Use CoreUI Sidebar Header component instead of footer so that stylings for CoreUI Sidebar Brand component work -->
       <CSidebarBrand>
         <div class="sidebar-brand-full">
           <img
-            data-testid="logo"
+            data-testid="ji-logo-sidebar"
             class="img-fluid mb-1"
             :title="versionTooltipContent"
             src="~/assets/img/IMPERIAL_JAMEEL_INSTITUTE_LOCKUP-p-500.png"
@@ -33,16 +33,10 @@
 <script lang="ts" setup>
 import { CIcon } from "@coreui/icons-vue";
 
+defineProps<{
+  versionTooltipContent: string | undefined
+}>();
 const appStore = useAppStore();
-
-const versionTooltipContent = computed(() => {
-  const vers = appStore.versions;
-  if (vers) {
-    return `Model version: ${vers.daedalusModel} \nR API version: ${vers.daedalusApi} \nWeb app version: ${vers.daedalusWebApp}`;
-  } else {
-    return undefined;
-  }
-});
 
 const visible = defineModel("visible", { type: Boolean, required: true });
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,8 +3,10 @@
     <!-- <WebsocketConnection /> -->
     <SideBar
       v-model:visible="sidebarVisible"
+      :version-tooltip-content="versionTooltipContent"
     />
     <AppHeader
+      :version-tooltip-content="versionTooltipContent"
       @toggle-sidebar-visibility="handleToggleSidebarVisibility"
     />
     <div class="wrapper d-flex flex-column">
@@ -26,6 +28,15 @@ function handleToggleSidebarVisibility() {
 }
 
 const appStore = useAppStore();
+
+const versionTooltipContent = computed(() => {
+  const vers = appStore.versions;
+  if (vers) {
+    return `Model version: ${vers.daedalusModel} \nR API version: ${vers.daedalusApi} \nWeb app version: ${vers.daedalusWebApp}`;
+  } else {
+    return undefined;
+  }
+});
 
 const setScreenSize = () => {
   const breakpoint = 992; // CoreUI's "lg" breakpoint

--- a/tests/e2e/helpers/waitForNewScenarioPage.ts
+++ b/tests/e2e/helpers/waitForNewScenarioPage.ts
@@ -8,5 +8,5 @@ export default async (page: Page, baseURL: string | undefined) => {
   await expect(page.getByText("Simulate a new scenario")).toBeVisible();
 
   // Reduce flakeyness of tests by waiting for evidence that the page has mounted.
-  await expect(page.getByTitle(/Web app version: 0.0.2/)).toHaveCount(1);
+  await expect(page.getByTitle(/Web app version: 0.0.2/)).toHaveCount(2);
 };

--- a/tests/unit/components/AppHeader.spec.ts
+++ b/tests/unit/components/AppHeader.spec.ts
@@ -1,13 +1,17 @@
 import AppHeader from "@/components/AppHeader.vue";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { waitFor } from "@testing-library/vue";
+import { mockVersions } from "../mocks/mockPinia";
 
 const stubs = {
   CIcon: true,
 };
 
+const versionTooltipContent = `Model version: ${mockVersions.daedalusModel} \nR API version: ${mockVersions.daedalusApi} \nWeb app version: ${mockVersions.daedalusWebApp}`;
+
 describe("app header", () => {
   it('emits "toggleSidebarVisibility" event when CHeaderToggler is clicked', async () => {
-    const component = await mountSuspended(AppHeader, { global: { stubs } });
+    const component = await mountSuspended(AppHeader, { global: { stubs }, props: { versionTooltipContent } });
 
     await component.findComponent({ name: "CHeaderToggler" }).vm.$emit("click");
     expect(component.emitted()).toHaveProperty("toggleSidebarVisibility");
@@ -17,7 +21,7 @@ describe("app header", () => {
     const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
-    const component = await mountSuspended(AppHeader, { global: { stubs } });
+    const component = await mountSuspended(AppHeader, { global: { stubs }, props: { versionTooltipContent } });
     expect(addEventListenerSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
 
     const header = component.findComponent({ name: "CHeader" });
@@ -38,5 +42,22 @@ describe("app header", () => {
 
     addEventListenerSpy.mockRestore();
     removeEventListenerSpy.mockRestore();
+  });
+
+  it("should render logo and include information about the version numbers", async () => {
+    const component = await mountSuspended(AppHeader, {
+      props: { versionTooltipContent },
+      global: { stubs },
+    });
+
+    await waitFor(() => {
+      const logoTitleAttribute = component
+        .find(`[data-testid="ji-logo-header"]`)
+        .attributes()
+        .title;
+      expect(logoTitleAttribute).toContain("Model version: 1.2.3");
+      expect(logoTitleAttribute).toContain("R API version: 4.5.6");
+      expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
+    });
   });
 });

--- a/tests/unit/components/SideBar.spec.ts
+++ b/tests/unit/components/SideBar.spec.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from "@vue/test-utils";
 import SideBar from "@/components/SideBar.vue";
-import { mockPinia } from "@/tests/unit/mocks/mockPinia";
+import { mockPinia, mockVersions } from "@/tests/unit/mocks/mockPinia";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
 
@@ -13,16 +13,17 @@ const mockCSidebarPageloadBehavior = async (coreuiSidebar: VueWrapper) => {
   coreuiSidebar.vm.$emit("hide");
 };
 
-const mockedVersions = { daedalusModel: "1.2.3", daedalusApi: "4.5.6", daedalusWebApp: "7.8.9" };
-
+const versionTooltipContent = `Model version: ${mockVersions.daedalusModel} \nR API version: ${mockVersions.daedalusApi} \nWeb app version: ${mockVersions.daedalusWebApp}`;
 describe("sidebar", () => {
   describe('when the "visible" prop is initialized as false', () => {
     describe("on smaller devices", () => {
-      const plugins = [mockPinia({ largeScreen: false, versions: mockedVersions })];
+      const plugins = [
+        mockPinia({ largeScreen: false }),
+      ];
 
       it('starts as hidden, and can be opened by setting "visible" prop', async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false },
+          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });
@@ -37,14 +38,17 @@ describe("sidebar", () => {
         expect(coreuiSidebar.props("unfoldable")).toBe(false);
       });
 
-      it("includes information about the version numbers", async () => {
+      it("should render logo and include information about the version numbers", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false },
+          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
 
         await waitFor(() => {
-          const logoTitleAttribute = component.find(`[data-testid="logo"]`).attributes().title;
+          const logoTitleAttribute = component
+            .find(`[data-testid="ji-logo-sidebar"]`)
+            .attributes()
+            .title;
           expect(logoTitleAttribute).toContain("Model version: 1.2.3");
           expect(logoTitleAttribute).toContain("R API version: 4.5.6");
           expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
@@ -53,11 +57,13 @@ describe("sidebar", () => {
     });
 
     describe("on larger devices", () => {
-      const plugins = [mockPinia({ largeScreen: true, versions: mockedVersions })];
+      const plugins = [
+        mockPinia({ largeScreen: true }),
+      ];
 
       it("starts as shown", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false },
+          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });
@@ -69,7 +75,7 @@ describe("sidebar", () => {
 
       it("renders the text and href for nav items", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false },
+          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -30,14 +30,18 @@ describe("default layout", () => {
     removeEventListenerSpy.mockRestore();
   });
 
-  it("includes information about the version numbers", async () => {
+  it("should render JI logo on sidebar and header", async () => {
     const component = await mountSuspended(DefaultLayout, { global: { stubs } });
 
+    const headerLogo = component.find(`[data-testid="ji-logo-header"]`);
+    const sidebarLogo = component.find(`[data-testid="ji-logo-sidebar"]`);
+
+    expect(headerLogo.isVisible()).toBe(true);
+    expect(sidebarLogo.isVisible()).toBe(true);
     await waitFor(() => {
-      const logoTitleAttribute = component.find(`[data-testid="logo"]`).attributes().title;
-      expect(logoTitleAttribute).toContain("Model version: 1.2.3");
-      expect(logoTitleAttribute).toContain("R API version: 4.5.6");
-      expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
+      expect(headerLogo.attributes().title).toContain("Model version: 1.2.3");
+      expect(headerLogo.attributes().title).toContain("R API version: 4.5.6");
+      expect(headerLogo.attributes().title).toContain("Web app version: 7.8.9");
     });
   });
 

--- a/tests/unit/mocks/mockPinia.ts
+++ b/tests/unit/mocks/mockPinia.ts
@@ -213,6 +213,13 @@ export const emptyScenario = {
 };
 Object.freeze(emptyScenario);
 
+export const mockVersions = {
+  daedalusModel: "1.2.3",
+  daedalusApi: "4.5.6",
+  daedalusWebApp: "7.8.9",
+};
+Object.freeze(mockVersions);
+
 export const mockPinia = (
   appState: Partial<AppState> = {},
   includeMetadata: boolean = true,
@@ -221,7 +228,7 @@ export const mockPinia = (
   const initialState = {
     app: {
       largeScreen: true,
-      versions: undefined,
+      versions: mockVersions,
       metadata: includeMetadata ? { ...mockedMetadata } : undefined,
       metadataFetchError: undefined,
       metadataFetchStatus: includeMetadata ? "success" : undefined,


### PR DESCRIPTION
This PR moves the JI logo to the top right corner form the sidebar. However on mobile mode it still shows in the sidebar. this is because not enough room on app header in mobile mode.

![image](https://github.com/user-attachments/assets/191fbd97-0e1c-4749-a0ac-ae79a3cf6b09)
![image](https://github.com/user-attachments/assets/7fded718-8c40-4d61-b623-ab006118ffd2)
![image](https://github.com/user-attachments/assets/bceb7110-d909-49da-8900-622241977da8)
