### PR TITLE
Fix globe rotation bugs

### DIFF
--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -201,10 +201,10 @@ const rotateChart = (direction: "x" | "y", to: number) => {
       diffRotation = diffRotation - 360;
     }
     // gets actual rotation destination by adding the difference
-    const toMod360 = currentXRotation + diffRotation;
+    const toShortest = currentXRotation + diffRotation;
     chart.animate({
       key: "rotationX",
-      to: toMod360,
+      to: toShortest,
       duration: rotateDuration,
       easing,
     });

--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -191,12 +191,31 @@ const pauseAnimations = () => {
 };
 
 const rotateChart = (direction: "x" | "y", to: number) => {
-  chart.animate({
-    key: (direction === "x" ? "rotationX" : "rotationY"),
-    to,
-    duration: rotateDuration,
-    easing,
-  });
+  if (direction === "x") {
+    const currentXRotation = chart.get("rotationX")!;
+    // calculates the smallest rotation between 0 amd 360 to get to the country
+    let diffRotation = (to - currentXRotation) % 360;
+    // translates rotation to between -180 and 180 because rotating 270 east
+    // is the same as 90 west
+    if (diffRotation > 180) {
+      diffRotation = diffRotation - 360;
+    }
+    // gets actual rotation destination by adding the difference
+    const toMod360 = currentXRotation + diffRotation;
+    chart.animate({
+      key: "rotationX",
+      to: toMod360,
+      duration: rotateDuration,
+      easing,
+    });
+  } else {
+    chart.animate({
+      key: "rotationY",
+      to,
+      duration: rotateDuration,
+      easing,
+    });
+  }
 };
 
 const rotateToCentroid = (centroid: am5.IGeoPoint, countryIso: string) => {
@@ -248,7 +267,7 @@ const createRotateAnimation = () => {
   return chart.animate({
     key: "rotationX",
     from: currentRotationX,
-    to: 360 - currentRotationX,
+    to: 360 + currentRotationX,
     duration: 180000,
     loops: Infinity,
   });


### PR DESCRIPTION
This fixes 2 bugs:
1. the globe has a gentle rotation animation however the starting rotation and the ending rotation were not the same points so one the animation stopped (in 180s, you can change it to less time in the code if you want to see it) the globe jumped to the starting rotation, this was just a case of replacing the `-` to a `+` so now the starting and ending rotations have a difference of 360 degs, i.e. no difference visually
2. if you select a country, spin the globe around 2 revolutions or so and pick another country, the globe would reverse your manual rotation and then spin to the country, we would like it to pick the shortest path of rotation so have done that with some maths