### PR TITLE
jidea-174 hide globe in about page

### DIFF
--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-show="appStore.globeParameter && appStore.largeScreen"
+    v-show="showGlobe"
     @mousedown="deselectText"
     @touchstart="deselectText"
     @mousemove="onMouseMove"
@@ -127,6 +127,8 @@ const prevBackgroundPolygon = ref<am5map.MapPolygon | undefined>(undefined);
 const prevSelectablePolygon = ref<am5map.MapPolygon | undefined>(undefined);
 
 const findFeatureForCountry = (countryIso: string) => WHONationalBorders.features.find(f => f.id === countryIso);
+
+const showGlobe = computed(() => appStore.globeParameter && appStore.largeScreen && route.path !== "/about");
 
 const highlightedCountrySeries = computed(() => {
   if (!appStore.globe.highlightedCountry) {


### PR DESCRIPTION
Prevents distracting planetary intrusion while perusing the About page.. 
This might not be the most sustainable approach once there are other pages - though I think most of those may have the background globe - but since the Globe is already making decisions based on the route, this seemed a reasonable place to put it. 