### PR TITLE
jidea-178 move version info to about page

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -19,7 +19,6 @@
           data-testid="ji-logo-header"
           style="width: 150px;"
           class="img-fluid"
-          :title="versionTooltipContent"
           src="~/assets/img/IMPERIAL_JAMEEL_INSTITUTE_LOCKUP-p-500.png"
           alt="Imperial College and Community Jameel logo"
         >
@@ -32,9 +31,6 @@
 import { CIcon } from "@coreui/icons-vue";
 import throttle from "lodash.throttle";
 
-defineProps<{
-  versionTooltipContent: string | undefined
-}>();
 defineEmits<{
   toggleSidebarVisibility: []
 }>();

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -34,7 +34,6 @@
           <img
             data-testid="ji-logo-sidebar"
             class="img-fluid mb-1"
-            :title="versionTooltipContent"
             src="~/assets/img/IMPERIAL_JAMEEL_INSTITUTE_LOCKUP-p-500.png"
             alt="Imperial College and Community Jameel logo"
           >
@@ -47,9 +46,6 @@
 <script lang="ts" setup>
 import { CIcon } from "@coreui/icons-vue";
 
-defineProps<{
-  versionTooltipContent: string | undefined
-}>();
 const appStore = useAppStore();
 
 const visible = defineModel("visible", { type: Boolean, required: true });

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,10 +3,8 @@
     <!-- <WebsocketConnection /> -->
     <SideBar
       v-model:visible="sidebarVisible"
-      :version-tooltip-content="versionTooltipContent"
     />
     <AppHeader
-      :version-tooltip-content="versionTooltipContent"
       @toggle-sidebar-visibility="handleToggleSidebarVisibility"
     />
     <div class="wrapper d-flex flex-column">
@@ -29,15 +27,6 @@ const loadGlobeComponent = ref(false);
 function handleToggleSidebarVisibility() {
   sidebarVisible.value = !sidebarVisible.value;
 }
-
-const versionTooltipContent = computed(() => {
-  const vers = appStore.versions;
-  if (vers) {
-    return `Model version: ${vers.daedalusModel} \nR API version: ${vers.daedalusApi} \nWeb app version: ${vers.daedalusWebApp}`;
-  } else {
-    return undefined;
-  }
-});
 
 const setScreenSize = () => {
   const breakpoint = 992; // CoreUI's "lg" breakpoint

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus-web-app",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -127,6 +127,14 @@
       in Apache License via
       <a href="https://www.svgrepo.com/" target="_blank">SVG Repo</a>
     </p>
+    <template v-if="appStore.versions">
+      <h2>Version</h2>
+      <ul>
+        <li>Model version: {{ appStore.versions.daedalusModel }}</li>
+        <li>R API version: {{ appStore.versions.daedalusApi }}</li>
+        <li>Web app version: {{ appStore.versions.daedalusWebApp }}</li>
+      </ul>
+    </template>
     <h2>References</h2>
     <ol>
       <li>

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+
+test("can see version info in About page", async ({ page, baseURL }) => {
+  await page.goto(`${baseURL}/about`);
+  await expect(page.getByText("The DAEDALUS Explore dashboard", { exact: true })).toBeVisible();
+  await expect(page.getByText(/Model version: \d+\.\d+\.\d/)).toBeVisible();
+  await expect(page.getByText(/R API version: \d+\.\d+\.\d/)).toBeVisible();
+  await expect(page.getByText(/Web app version: \d+\.\d+\.\d/)).toBeVisible();
+});

--- a/tests/e2e/helpers/waitForNewScenarioPage.ts
+++ b/tests/e2e/helpers/waitForNewScenarioPage.ts
@@ -8,5 +8,5 @@ export default async (page: Page, baseURL: string | undefined) => {
   await expect(page.getByText("Simulate a new scenario")).toBeVisible();
 
   // Reduce flakeyness of tests by waiting for evidence that the page has mounted.
-  await expect(page.getByTitle(/Web app version: 0.0.2/)).toHaveCount(2);
+  await expect(page.getByText(/Country/)).toBeVisible();
 };

--- a/tests/unit/components/AppHeader.spec.ts
+++ b/tests/unit/components/AppHeader.spec.ts
@@ -1,17 +1,14 @@
 import AppHeader from "@/components/AppHeader.vue";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
-import { mockVersions } from "../mocks/mockPinia";
 
 const stubs = {
   CIcon: true,
 };
 
-const versionTooltipContent = `Model version: ${mockVersions.daedalusModel} \nR API version: ${mockVersions.daedalusApi} \nWeb app version: ${mockVersions.daedalusWebApp}`;
-
 describe("app header", () => {
   it('emits "toggleSidebarVisibility" event when CHeaderToggler is clicked', async () => {
-    const component = await mountSuspended(AppHeader, { global: { stubs }, props: { versionTooltipContent } });
+    const component = await mountSuspended(AppHeader, { global: { stubs } });
 
     await component.findComponent({ name: "CHeaderToggler" }).vm.$emit("click");
     expect(component.emitted()).toHaveProperty("toggleSidebarVisibility");
@@ -21,7 +18,7 @@ describe("app header", () => {
     const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
 
-    const component = await mountSuspended(AppHeader, { global: { stubs }, props: { versionTooltipContent } });
+    const component = await mountSuspended(AppHeader, { global: { stubs } });
     expect(addEventListenerSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
 
     const header = component.findComponent({ name: "CHeader" });
@@ -44,20 +41,17 @@ describe("app header", () => {
     removeEventListenerSpy.mockRestore();
   });
 
-  it("should render logo and include information about the version numbers", async () => {
+  it("should render logo", async () => {
     const component = await mountSuspended(AppHeader, {
-      props: { versionTooltipContent },
       global: { stubs },
     });
 
     await waitFor(() => {
-      const logoTitleAttribute = component
+      const logoSrcAttribute = component
         .find(`[data-testid="ji-logo-header"]`)
         .attributes()
-        .title;
-      expect(logoTitleAttribute).toContain("Model version: 1.2.3");
-      expect(logoTitleAttribute).toContain("R API version: 4.5.6");
-      expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
+        .src;
+      expect(logoSrcAttribute).toContain("IMPERIAL_JAMEEL_INSTITUTE");
     });
   });
 });

--- a/tests/unit/components/SideBar.spec.ts
+++ b/tests/unit/components/SideBar.spec.ts
@@ -1,6 +1,6 @@
 import type { VueWrapper } from "@vue/test-utils";
 import SideBar from "@/components/SideBar.vue";
-import { mockPinia, mockVersions } from "@/tests/unit/mocks/mockPinia";
+import { mockPinia } from "@/tests/unit/mocks/mockPinia";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { waitFor } from "@testing-library/vue";
 
@@ -13,7 +13,6 @@ const mockCSidebarPageloadBehavior = async (coreuiSidebar: VueWrapper) => {
   coreuiSidebar.vm.$emit("hide");
 };
 
-const versionTooltipContent = `Model version: ${mockVersions.daedalusModel} \nR API version: ${mockVersions.daedalusApi} \nWeb app version: ${mockVersions.daedalusWebApp}`;
 describe("sidebar", () => {
   describe('when the "visible" prop is initialized as false', () => {
     describe("on smaller devices", () => {
@@ -23,7 +22,7 @@ describe("sidebar", () => {
 
       it('starts as hidden, and can be opened by setting "visible" prop', async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false, versionTooltipContent },
+          props: { visible: false },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });
@@ -38,20 +37,18 @@ describe("sidebar", () => {
         expect(coreuiSidebar.props("unfoldable")).toBe(false);
       });
 
-      it("should render logo and include information about the version numbers", async () => {
+      it("should render logo", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false, versionTooltipContent },
+          props: { visible: false },
           global: { stubs, plugins },
         });
 
         await waitFor(() => {
-          const logoTitleAttribute = component
+          const logoSrcAttribute = component
             .find(`[data-testid="ji-logo-sidebar"]`)
             .attributes()
-            .title;
-          expect(logoTitleAttribute).toContain("Model version: 1.2.3");
-          expect(logoTitleAttribute).toContain("R API version: 4.5.6");
-          expect(logoTitleAttribute).toContain("Web app version: 7.8.9");
+            .src;
+          expect(logoSrcAttribute).toContain("IMPERIAL_JAMEEL_INSTITUTE");
         });
       });
     });
@@ -63,7 +60,6 @@ describe("sidebar", () => {
 
       it("starts as shown", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });
@@ -75,7 +71,6 @@ describe("sidebar", () => {
 
       it("renders the text and href for nav items", async () => {
         const component = await mountSuspended(SideBar, {
-          props: { visible: false, versionTooltipContent },
           global: { stubs, plugins },
         });
         const coreuiSidebar = component.findComponent({ name: "CSidebar" });

--- a/tests/unit/components/defaultLayout.spec.ts
+++ b/tests/unit/components/defaultLayout.spec.ts
@@ -1,6 +1,5 @@
 import DefaultLayout from "@/layouts/default.vue";
 import { mountSuspended, registerEndpoint } from "@nuxt/test-utils/runtime";
-import { waitFor } from "@testing-library/vue";
 
 const stubs = {
   CIcon: true,
@@ -38,11 +37,6 @@ describe("default layout", () => {
 
     expect(headerLogo.isVisible()).toBe(true);
     expect(sidebarLogo.isVisible()).toBe(true);
-    await waitFor(() => {
-      expect(headerLogo.attributes().title).toContain("Model version: 1.2.3");
-      expect(headerLogo.attributes().title).toContain("R API version: 4.5.6");
-      expect(headerLogo.attributes().title).toContain("Web app version: 7.8.9");
-    });
   });
 
   describe("on smaller devices", () => {

--- a/tests/unit/pages/About.spec.ts
+++ b/tests/unit/pages/About.spec.ts
@@ -1,7 +1,7 @@
 import About from "@/pages/about.vue";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { describe, expect, it } from "vitest";
-import { countryAndPathogenParams, mockedMetadata, mockPinia } from "../mocks/mockPinia";
+import { countryAndPathogenParams, mockedMetadata, mockPinia, mockVersions } from "../mocks/mockPinia";
 
 describe("about page", () => {
   it("should render about with correct metadata info", async () => {
@@ -9,6 +9,7 @@ describe("about page", () => {
     const numberOfCountries = countryAndPathogenParams.find(p => p.id === "country")!.options!.length;
     const component = await mountSuspended(About, { global: { plugins: [mockPinia({
       metadata: { ...mockedMetadata, parameters: countryAndPathogenParams as any },
+      versions: mockVersions,
     })] } });
 
     const text = component.text();
@@ -19,5 +20,8 @@ describe("about page", () => {
     for (const estimate of mockedMetadata.results.time_series_groups) {
       expect(text).toContain(estimate.label);
     }
+    expect(text).toContain("Model version: 1.2.3");
+    expect(text).toContain("R API version: 4.5.6");
+    expect(text).toContain("Web app version: 7.8.9");
   });
 });

--- a/tests/unit/server/handlers/versions.spec.ts
+++ b/tests/unit/server/handlers/versions.spec.ts
@@ -1,3 +1,4 @@
+import packageJson from "@/package.json";
 import { getVersionData } from "@/server/handlers/versions";
 import { registerEndpoint } from "@nuxt/test-utils/runtime";
 
@@ -24,8 +25,10 @@ describe("get version data", () => {
       expect(response.data).toEqual({
         daedalusApi: "0.1.999",
         daedalusModel: "0.1.0",
-        daedalusWebApp: "0.0.2",
+        daedalusWebApp: packageJson.version,
       });
+      // Check we have a sensible version string in the package
+      expect(response.data?.daedalusWebApp).toMatch(/\d+\.\d+\.\d/);
       expect(response.errors).toBeNull();
       expect(response.statusCode).toBe(200);
       expect(response.statusText).toBe("");


### PR DESCRIPTION
Add version info to the bottom of the About page, and remove it as random tooltip on brand logo!

Took this opportunity to update the web app version, which we have not been doing well at!

Arguably we could move the versions fetch out of the default layout and into the About page, but it feels like it makes sense to keep it in the layout, as it is also fetching the metadata. I've added an e2e test to make sure it all works together.