### PR TITLE
Pass dedupe 'defer' option to useFetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus-web-app",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "engines": {
     "node": ">=20"

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -70,7 +70,7 @@ export const useAppStore = defineStore("app", {
         data: scenarioStatusData,
         status: scenarioStatusFetchStatus,
         error: scenarioStatusFetchError,
-      } = await useFetch(`/api/scenarios/${this.currentScenario.runId}/status`) as {
+      } = await useFetch(`/api/scenarios/${this.currentScenario.runId}/status`, { dedupe: "defer" }) as {
         data: Ref<ScenarioStatusData>
         status: Ref<AsyncDataRequestStatus>
         error: Ref<FetchError>


### PR DESCRIPTION
https://nuxt.com/docs/api/composables/use-fetch\#params

The default value for this option is 'cancel' - which means that if a new identical request is made, it cancels any ones that are still waiting for their responses.

On slow networks we saw that about half the time, a status poll request resulted in useFetch cacheing the status as 'running' for a long time (minutes) even though new requests were returning the correct status ('completed'). Given that the dedupe option fixes it, it was presumably because new requests were constantly being cancelled when the polling interval came around again, before they had had a chance to return anything (on a slow network speed).