### PR TITLE
Globe: Color disputed lands according to neighboring countries' color

### DIFF
--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -63,11 +63,12 @@ const disputedLands: Record<string, {
   disputers: string[]
   mapSeries: am5map.MapPolygonSeries | null
   displayed: boolean
+  colorAsSelectable: boolean
 }> = {
-  "Western Sahara": { disputers: ["ESH", "MAR"], mapSeries: null, displayed: false },
-  "Abyei": { disputers: ["SSD", "SDN"], mapSeries: null, displayed: false },
-  "Aksai Chin": { disputers: ["CHN", "IND"], mapSeries: null, displayed: false },
-  "Jammu and Kashmir": { disputers: ["IND", "PAK", "CHN"], mapSeries: null, displayed: false },
+  "Western Sahara": { disputers: ["ESH", "MAR"], mapSeries: null, displayed: false, colorAsSelectable: false },
+  "Abyei": { disputers: ["SSD", "SDN"], mapSeries: null, displayed: false, colorAsSelectable: false },
+  "Aksai Chin": { disputers: ["CHN", "IND"], mapSeries: null, displayed: false, colorAsSelectable: true },
+  "Jammu and Kashmir": { disputers: ["IND", "PAK", "CHN"], mapSeries: null, displayed: false, colorAsSelectable: true },
 };
 const chartDefaultSettings: am5map.IMapChartSettings = {
   panX: "rotateX",
@@ -112,7 +113,6 @@ const disputedAreaSeriesSettings: am5map.IMapPolygonSeriesSettings = {
 // Settings for disputed *land* areas - see 'Customization' in shapefiles.md
 const disputedLandSeriesSettings: am5map.IMapPolygonSeriesSettings = {
   ...disputedAreaSeriesSettings,
-  fill: defaultLandColour,
   layer: maxZindex - 1, // Make sure disputed areas are always painted on top of country areas
 };
 // Settings for disputed *water* areas - see 'Customization' in shapefiles.md
@@ -339,6 +339,7 @@ const setUpDisputedAreasSeries = () => {
       ...disputedLandSeriesSettings,
       reverseGeodata: true,
       include: [disputedArea],
+      fill: disputedLands[disputedArea].colorAsSelectable ? defaultLandColour : unselectableLandColor,
     });
   });
 


### PR DESCRIPTION
The intention is to prevent the Abyei region (between Sudan and South Sudan) from looking like a selectable country, which it did because it was colored with the default color but was surrounded by unselectable countries.

## Before

![Screenshot from 2024-11-11 13-52-12](https://github.com/user-attachments/assets/83219a88-791e-4d71-9ab5-11c1757ecd30)

## After

![Screenshot from 2024-11-11 13-52-29](https://github.com/user-attachments/assets/bc0b2124-1a3a-494b-9d7a-2d5ec8b99bf9)