### PR TITLE
Fix globe component

### DIFF
--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -196,7 +196,7 @@ const setUpBackgroundSeries = () => {
 };
 
 const setUpAntarcticaSeries = () => {
-  initializeSeries({ ...backgroundSeriesSettings, geoJSON: worldLow, include: ["AQ"] });
+  initializeSeries(root, chart, { ...backgroundSeriesSettings, geoJSON: worldLow, include: ["AQ"] });
 };
 
 const setUpSelectableCountriesSeries = () => {


### PR DESCRIPTION
Currently on main the antarctica series is missing from the globe, as are the colors, and the ability to hover and select.

This change should have been added in a merge of the globe refactor PR and the Antarctica PR, but wasn't.

These failures should be caught by the component tests next time, once the branch with tests in is merged.