### PR TITLE
Cache the versions endpoint

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,9 @@
 import process from "node:process";
 
 const cacheRoute = (maxAge: number) => {
-  // Don't cache endpoints during tests, so that tests are isolated.
+  // Don't cache endpoints during integration tests, so that tests are isolated.
+  // In end-to-end tests, this variable evaluates to "production" so long as Playwright is using
+  // a built version of the app rather than `npm run dev`.
   return process.env.NODE_ENV === "test" ? {} : { cache: { maxAge } };
 };
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,10 @@
+import process from "node:process";
+
+const cacheRoute = (maxAge: number) => {
+  // Don't cache endpoints during tests, so that tests are isolated.
+  return process.env.NODE_ENV === "test" ? {} : { cache: { maxAge } };
+};
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   build: {
@@ -21,6 +28,7 @@ export default defineNuxtConfig({
     },
     routeRules: {
       "/": { redirect: "/scenarios/new" },
+      "/api/versions": cacheRoute(60),
     },
   },
 


### PR DESCRIPTION
Previously, I gave up trying to cache endpoints because I couldn't see a way to purge the cache between tests so that the tests didn't alter each other's effects. But then this way occurred to me: refer to an environment variable in the app config to decide whether a route is cached or not.