### PR TITLE
Highlight the 'edit parameters' button when the baseline value's tooltip is shown

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -24,6 +24,26 @@
   }
 }
 
+.pulse {
+  animation: pulse-animation 0.5s 1;
+
+  &.infinite {
+    animation: pulse-animation 0.5s infinite;
+  }
+}
+
+@keyframes pulse-animation {
+  0% {
+    box-shadow: 0 0 0 0px rgba(0, 0, 255, 0.25);
+  }
+  90% {
+    box-shadow: 0 0 0 13.5px rgba(0, 0, 255, 0.01);
+  }
+  100% {
+    box-shadow: 0 0 0 15px rgba(0, 0, 255, 0);
+  }
+}
+
 // Global customization 'Vue 3 Select Component', overriding styles applied to :root pseudoclass.
 :root body {
   --vs-font-size: 1.25rem;

--- a/components/ParameterForm.vue
+++ b/components/ParameterForm.vue
@@ -435,26 +435,6 @@ onMounted(() => {
   margin-top: 2rem; // Align button with height of labels when it shares a row with an input.
 }
 
-.pulse {
-  animation: pulse-animation 0.5s 1;
-
-  &.infinite {
-    animation: pulse-animation 0.5s infinite;
-  }
-}
-
-@keyframes pulse-animation {
-  0% {
-    box-shadow: 0 0 0 0px rgba(0, 0, 255, 0.25);
-  }
-  90% {
-    box-shadow: 0 0 0 13.5px rgba(0, 0, 255, 0.01);
-  }
-  100% {
-    box-shadow: 0 0 0 15px rgba(0, 0, 255, 0);
-  }
-}
-
 .select-container {
    margin-left: 0.7rem;
    margin-right: 0.55rem;

--- a/components/ParameterInfoCard.vue
+++ b/components/ParameterInfoCard.vue
@@ -4,6 +4,7 @@
       <div
         v-show="!appStore.largeScreen"
         class="card-header h-100 align-content-center"
+        :class="props.pulseEditButton ? 'pulse infinite' : ''"
       >
         <EditParameters />
       </div>
@@ -33,7 +34,10 @@
         </div>
       </CCol>
       <CCol v-show="appStore.largeScreen" class="col-auto">
-        <div class="card-footer h-100 align-content-center">
+        <div
+          class="card-footer h-100 align-content-center"
+          :class="props.pulseEditButton ? 'pulse infinite' : ''"
+        >
           <EditParameters />
         </div>
       </CCol>
@@ -46,6 +50,10 @@ import { CIcon } from "@coreui/icons-vue";
 import getCountryISO2 from "country-iso-3-to-2";
 import type { Parameter } from "~/types/parameterTypes";
 import { humanReadableNumber } from "./utils/formatters";
+
+const props = defineProps<{
+  pulseEditButton: boolean
+}>();
 
 const appStore = useAppStore();
 

--- a/pages/scenarios/[runId].vue
+++ b/pages/scenarios/[runId].vue
@@ -4,7 +4,7 @@
       <h1 class="fs-2 mb-0 pt-1">
         Results
       </h1>
-      <CreateComparison />
+      <CreateComparison @toggle-edit-params-button-pulse="handleToggleEditParamsButtonPulse" />
       <DownloadExcel />
       <CodeSnippet />
       <CAlert class="d-sm-none d-flex gap-4 align-items-center" color="info" dismissible>
@@ -16,7 +16,7 @@
           Rotate your mobile device to landscape for the best experience.
         </p>
       </CAlert>
-      <ParameterInfoCard />
+      <ParameterInfoCard :pulse-edit-button="pulseEditParamsButton" />
     </div>
     <CSpinner v-show="showSpinner" class="ms-3 mb-3 mt-3" />
     <CAlert v-if="appStore.currentScenario.status.data?.runSuccess === false" color="danger">
@@ -64,6 +64,7 @@ const appStore = useAppStore();
 let statusInterval: NodeJS.Timeout;
 const jobSlow = ref(false);
 const jobReallySlow = ref(false);
+const pulseEditParamsButton = ref(false);
 const secondsSinceFirstStatusPoll = ref("0");
 const showSpinner = computed(() => !appStore.currentScenario.result.data
   && appStore.currentScenario.status.data?.runSuccess !== false
@@ -111,6 +112,10 @@ const pollForStatusEveryNSeconds = (seconds: number) => {
     };
     appStore.loadScenarioStatus();
   }, seconds * 1000);
+};
+
+const handleToggleEditParamsButtonPulse = (on: boolean) => {
+  pulseEditParamsButton.value = on;
 };
 
 onMounted(() => {

--- a/tests/unit/components/CreateComparison.spec.ts
+++ b/tests/unit/components/CreateComparison.spec.ts
@@ -1,7 +1,6 @@
 import CreateComparison from "@/components/CreateComparison.vue";
 import { emptyScenario, mockPinia, mockResultData } from "@/tests/unit/mocks/mockPinia";
-import { flushPromises } from "@vue/test-utils";
-import type { VueWrapper } from "@vue/test-utils";
+import { flushPromises, type VueWrapper } from "@vue/test-utils";
 import { mockNuxtImport, mountSuspended } from "@nuxt/test-utils/runtime";
 
 import type { Metadata, ScenarioResultData } from "~/types/apiResponseTypes";
@@ -233,5 +232,91 @@ describe("create comparison button and modal", () => {
     // Page navigation should reset store downloadError
     const appStore = useAppStore();
     expect(appStore.downloadError).toBeUndefined();
+  });
+
+  it("on closing the modal, triggers the edit params to stop pulsing", async () => {
+    const wrapper = await mountSuspended(CreateComparison, { global: { stubs, plugins } });
+
+    await openModal(wrapper);
+
+    wrapper.find(".btn-close").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted()).not.toHaveProperty("toggleEditParamsButtonPulse");
+
+    vi.advanceTimersByTime(2000);
+
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")).toHaveLength(1);
+    // 'false' denotes stopping the pulse
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")?.[0][0]).toEqual(false);
+  });
+
+  it("on showing the tooltip, triggers the edit params button to pulse", async () => {
+    const wrapper = await mountSuspended(CreateComparison, { global: { stubs, plugins } });
+
+    await openModal(wrapper);
+
+    getModalEl(wrapper).find("#axisOptions").findAll("button")[0].trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const cTooltip = wrapper.findComponent({ name: "CTooltip" });
+    cTooltip.vm.$emit("show");
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")).toHaveLength(1);
+    // 'true' denotes starting the pulse
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")?.[0][0]).toEqual(true);
+    vi.advanceTimersByTime(10_000);
+    // no change
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")).toHaveLength(1);
+  });
+
+  it("on hiding the tooltip, triggers the edit params button to stop pulsing, after a delay", async () => {
+    const wrapper = await mountSuspended(CreateComparison, { global: { stubs, plugins } });
+
+    await openModal(wrapper);
+
+    getModalEl(wrapper).find("#axisOptions").findAll("button")[0].trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const cTooltip = wrapper.findComponent({ name: "CTooltip" });
+    cTooltip.vm.$emit("hide");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted()).not.toHaveProperty("toggleEditParamsButtonPulse");
+    vi.advanceTimersByTime(3000);
+
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")).toHaveLength(1);
+    // 'false' denotes stopping the pulse
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")?.[0][0]).toEqual(false);
+  });
+
+  it(`on closing the modal, if hiding the tooltip has not already triggered the edit params button to stop pulsing,`
+    + `it should restart the countdown and stop the pulse after a delay`, async () => {
+    const wrapper = await mountSuspended(CreateComparison, { global: { stubs, plugins } });
+
+    await openModal(wrapper);
+
+    getModalEl(wrapper).find("#axisOptions").findAll("button")[0].trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const cTooltip = wrapper.findComponent({ name: "CTooltip" });
+    cTooltip.vm.$emit("hide");
+    await wrapper.vm.$nextTick();
+
+    vi.advanceTimersByTime(2500);
+    expect(wrapper.emitted()).not.toHaveProperty("toggleEditParamsButtonPulse");
+
+    wrapper.find(".btn-close").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    vi.advanceTimersByTime(1500);
+    expect(wrapper.emitted()).not.toHaveProperty("toggleEditParamsButtonPulse");
+
+    vi.advanceTimersByTime(500);
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")).toHaveLength(1);
+    // 'false' denotes stopping the pulse
+    expect(wrapper.emitted("toggleEditParamsButtonPulse")?.[0][0]).toEqual(false);
   });
 });

--- a/tests/unit/components/ParameterInfoCard.spec.ts
+++ b/tests/unit/components/ParameterInfoCard.spec.ts
@@ -20,6 +20,7 @@ const plugins = [mockPinia({
 describe("parameter info card", () => {
   it("shows the parameters that were used to run the scenario", async () => {
     const component = await mountSuspended(ParameterInfoCard, {
+      props: { pulseEditButton: false },
       global: { stubs, plugins },
     });
 
@@ -29,5 +30,22 @@ describe("parameter info card", () => {
     expect(component.text()).toContain("No closures");
     expect(component.text()).toContain("None");
     expect(component.text()).toContain("30,500");
+  });
+
+  it("applies CSS classes to the edit buttons if pulseEditButton is updated", async () => {
+    const component = await mountSuspended(ParameterInfoCard, {
+      props: { pulseEditButton: false },
+      global: { stubs, plugins },
+    });
+
+    expect(component.find(".pulse.infinite").exists()).toBe(false);
+
+    await component.setProps({ pulseEditButton: true });
+
+    expect(component.find(".pulse.infinite").exists()).toBe(true);
+
+    await component.setProps({ pulseEditButton: false });
+
+    expect(component.find(".pulse.infinite").exists()).toBe(false);
   });
 });


### PR DESCRIPTION
This is an iteration on top of https://github.com/jameel-institute/daedalus-web-app/pull/107

There is a tooltip introduced by that PR that is shown when the user hovers over the baseline value inside the 'create comparison' modal. The tooltip reads "To change the baseline, exit the overlay and edit the current scenario's parameters."

The intention here is to make it clearer to the user where the relevant button is. I reuse the pulse animation we already have for drawing attention to form fields, and apply it to the button, but alongside an '.infinite' class so that we can precisely control the pulse switching on and off.

There are three interactions that can affect the pulse: hovering over the tooltip (starts pulse); closing the 'create comparison' modal (stops pulse after 2 seconds); and exiting the tooltip (stops pulse after 3 seconds).

The pulse durations differ because I was trying to strike a balance between (1) allowing the pulse to continue long enough after closing/exiting that the user sees it and (2) stopping it before it becomes annoying. The pulse is less obvious when the modal is visible, hence the longer duration on exiting the tooltip.

Because there are two triggers for stopping the pulse, each with their own different timeout, and we want to prioritise the effect of the most recent interaction (the most recent timeout to be created), all stop-triggers are routed through a single function, `turnOffEditParamsButtonPulse`, which replaces any already-existing timeout with the new timeout.
