### PR TITLE
Tiny refactor

### DIFF
--- a/components/CreateComparison.vue
+++ b/components/CreateComparison.vue
@@ -96,7 +96,6 @@ import { CIcon, CIconSvg } from "@coreui/icons-vue";
 import { TypeOfParameter } from "~/types/parameterTypes";
 import type { Parameter } from "~/types/parameterTypes";
 import { MAX_SCENARIOS_COMPARED_TO_BASELINE } from "~/components/utils/comparisons";
-import { useScenarioOptions } from "~/composables/useScenarioOptions";
 
 const appStore = useAppStore();
 const FORM_LABEL_ID = "scenarioOptions";

--- a/components/ScenarioSelect.vue
+++ b/components/ScenarioSelect.vue
@@ -44,7 +44,6 @@
 import VueSelect from "vue3-select-component";
 import type { Parameter } from "~/types/parameterTypes";
 import { MAX_SCENARIOS_COMPARED_TO_BASELINE } from "~/components/utils/comparisons";
-import { useScenarioOptions } from "~/composables/useScenarioOptions";
 
 const { showFeedback, parameterAxis, labelId } = defineProps<{
   showFeedback: boolean

--- a/composables/useComparisonValidation.ts
+++ b/composables/useComparisonValidation.ts
@@ -1,6 +1,6 @@
 import { MAX_SCENARIOS_COMPARED_TO_BASELINE, MIN_SCENARIOS_COMPARED_TO_BASELINE } from "~/components/utils/comparisons";
 
-export const useComparisonValidation = (scenariosToCompareAgainstBaseline: MaybeRefOrGetter<Array<string>>) => {
+export default (scenariosToCompareAgainstBaseline: MaybeRefOrGetter<Array<string>>) => {
   const tooFewScenarios = computed(() => toValue(scenariosToCompareAgainstBaseline).length < MIN_SCENARIOS_COMPARED_TO_BASELINE);
   const tooManyScenarios = computed(() => toValue(scenariosToCompareAgainstBaseline).length > MAX_SCENARIOS_COMPARED_TO_BASELINE);
   const invalid = computed(() => {

--- a/composables/useScenarioOptions.ts
+++ b/composables/useScenarioOptions.ts
@@ -1,7 +1,7 @@
 import { type Parameter, type ParameterOption, TypeOfParameter } from "~/types/parameterTypes";
 import { paramOptsToSelectOpts } from "~/components/utils/parameters";
 
-export const useScenarioOptions = (parameterAxis: MaybeRefOrGetter<Parameter | undefined>) => {
+export default (parameterAxis: MaybeRefOrGetter<Parameter | undefined>) => {
   const appStore = useAppStore();
 
   const baselineOption = computed(() => {

--- a/composables/useTimeSeriesAccordionHeights.ts
+++ b/composables/useTimeSeriesAccordionHeights.ts
@@ -1,4 +1,4 @@
-export const useTimeSeriesAccordionHeights = () => {
+export default () => {
   const appStore = useAppStore();
   const openedAccordions = ref<string[]>([]);
   const accordionBodyYPadding = 8;


### PR DESCRIPTION
If we use export defaults instead of redundantly naming functions inside composables files, then they get auto-imported.