### PR TITLE
JIDEA-284: Update the costs table to have a configurable cost basis and be collapsible

### DIFF
--- a/components/CostsCard.vue
+++ b/components/CostsCard.vue
@@ -73,7 +73,7 @@
       <div class="chart-and-table-container">
         <CostsChart id="costsChartContainer" />
         <div class="flex-grow-1">
-          <CostsTable data-testid="costs-table" :basis="costBasis" />
+          <CostsTable data-testid="costs-table" />
         </div>
       </div>
       <p class="fw-lighter vsl-display">

--- a/components/CostsCard.vue
+++ b/components/CostsCard.vue
@@ -73,7 +73,7 @@
       <div class="chart-and-table-container">
         <CostsChart id="costsChartContainer" />
         <div class="flex-grow-1">
-          <CostsTable data-testid="costs-table" />
+          <CostsTable data-testid="costs-table" :basis="costBasis" />
         </div>
       </div>
       <p class="fw-lighter vsl-display">

--- a/components/CostsTable.vue
+++ b/components/CostsTable.vue
@@ -1,43 +1,74 @@
 <template>
-  <table v-if="appStore.totalCost" class="table rounded table-hover table-sm">
+  <table v-if="appStore.totalCost?.children" class="table rounded table-hover table-sm" aria-label="Costs table">
     <thead class="border-bottom-2 border-black">
       <tr>
-        <th />
-        <th>$, millions</th>
+        <th>
+          <CButton
+            v-if="appStore.totalCost.children.length > 0"
+            class="btn p-0 text-decoration-none text-muted"
+            color="link"
+            :aria-expanded="accordioned"
+            :aria-label="accordioned ? 'Expand costs table' : 'Collapse costs table'"
+            aria-controls="costs-table-body"
+            @click="() => { accordioned = !accordioned; }"
+          >
+            <CIcon :icon="accordioned ? 'cilPlus' : 'cilMinus'" />
+            <span class="ps-1">{{ accordioned ? "Expand" : "Collapse" }} all</span>
+          </CButton>
+        </th>
+        <th>{{ basis === CostBasis.PercentGDP ? `% of ${gdpReferenceYear} GDP` : "$, millions" }}</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody id="costs-table-body">
       <template
-        v-for="childCost in appStore.totalCost.children?.toSorted(
-          (a, b) => b.value - a.value,
-        )"
+        v-for="(childCost) in appStore.totalCost.children"
         :key="childCost.id"
       >
         <tr>
-          <td class="ps-2">
+          <td class="ps-2 w-75">
             {{ appStore.getCostLabel(childCost.id) }}<span v-if="childCost.id === 'life_years'">*</span>
           </td>
-          <td>{{ formatCurrency(childCost.value) }}</td>
+          <td>{{ displayValue(childCost.value) }}</td>
         </tr>
-        <template v-if="childCost.children">
-          <tr
-            v-for="grandChildCost in childCost.children"
-            :key="grandChildCost.id"
-            class="nested-row fw-lighter"
-          >
-            <td class="ps-4">
-              {{ appStore.getCostLabel(grandChildCost.id) }}
-            </td>
-            <td>{{ formatCurrency(grandChildCost.value) }}</td>
-          </tr>
-        </template>
+        <tr
+          v-for="grandChildCost in childCost.children"
+          v-show="!accordioned"
+          :key="grandChildCost.id"
+          class="nested-row fw-lighter"
+        >
+          <td class="ps-4">
+            {{ appStore.getCostLabel(grandChildCost.id) }}
+          </td>
+          <td>{{ displayValue(grandChildCost.value) }}</td>
+        </tr>
       </template>
     </tbody>
   </table>
 </template>
 
 <script lang="ts" setup>
+import { CIcon } from "@coreui/icons-vue";
+import { costAsPercentOfGdp, gdpReferenceYear, humanReadablePercentOfGdp } from "./utils/formatters";
+import { CostBasis } from "~/types/unitTypes";
+
+const props = defineProps<{
+  basis: CostBasis
+}>();
+
+const accordioned = ref(true);
 const appStore = useAppStore();
+
+const displayValue = (valueInDollarTerms: number): string => {
+  switch (props.basis) {
+    case CostBasis.PercentGDP:
+    {
+      const percentOfGdp = costAsPercentOfGdp(valueInDollarTerms, appStore.currentScenario.result.data?.gdp);
+      return `${humanReadablePercentOfGdp(percentOfGdp).percent}%`;
+    }
+    case CostBasis.USD:
+      return formatCurrency(valueInDollarTerms);
+  }
+};
 </script>
 
 <style scoped>

--- a/components/CostsTable.vue
+++ b/components/CostsTable.vue
@@ -16,7 +16,7 @@
             <span class="ps-1">{{ accordioned ? "Expand" : "Collapse" }} all</span>
           </CButton>
         </th>
-        <th>{{ basis === CostBasis.PercentGDP ? `% of ${gdpReferenceYear} GDP` : "$, millions" }}</th>
+        <th>{{ appStore.preferences.costBasis === CostBasis.PercentGDP ? `% of ${gdpReferenceYear} GDP` : "$, millions" }}</th>
       </tr>
     </thead>
     <tbody id="costs-table-body">
@@ -51,15 +51,11 @@ import { CIcon } from "@coreui/icons-vue";
 import { costAsPercentOfGdp, gdpReferenceYear, humanReadablePercentOfGdp } from "./utils/formatters";
 import { CostBasis } from "~/types/unitTypes";
 
-const props = defineProps<{
-  basis: CostBasis
-}>();
-
 const accordioned = ref(true);
 const appStore = useAppStore();
 
 const displayValue = (valueInDollarTerms: number): string => {
-  switch (props.basis) {
+  switch (appStore.preferences.costBasis) {
     case CostBasis.PercentGDP:
     {
       const percentOfGdp = costAsPercentOfGdp(valueInDollarTerms, appStore.currentScenario.result.data?.gdp);

--- a/tests/unit/components/CostsCard.spec.ts
+++ b/tests/unit/components/CostsCard.spec.ts
@@ -73,9 +73,6 @@ describe("costs card", () => {
 
     expect(appStore.preferences.costBasis).toBe(CostBasis.USD);
 
-    // const costsTableComponent = component.findComponent({ name: "CostsTable" });
-    // expect(costsTableComponent.props("basis")).toBe(CostBasis.USD);
-
     const gdpRadioButton = component.find(`input[type="radio"][value="${CostBasis.PercentGDP}"]`);
     const usdRadioButton = component.find(`input[type="radio"][value="${CostBasis.USD}"]`);
     expect(gdpRadioButton.element.checked).toBe(false);
@@ -86,13 +83,11 @@ describe("costs card", () => {
     expect(gdpRadioButton.element.checked).toBe(true);
     expect(usdRadioButton.element.checked).toBe(false);
     expect(appStore.preferences.costBasis).toBe(CostBasis.PercentGDP);
-    // expect(costsTableComponent.props("basis")).toBe(CostBasis.PercentGDP);
 
     await usdRadioButton.setChecked();
 
     expect(gdpRadioButton.element.checked).toBe(false);
     expect(usdRadioButton.element.checked).toBe(true);
     expect(appStore.preferences.costBasis).toBe(CostBasis.USD);
-    // expect(costsTableComponent.props("basis")).toBe(CostBasis.USD);
   });
 });

--- a/tests/unit/components/CostsTable.spec.ts
+++ b/tests/unit/components/CostsTable.spec.ts
@@ -10,24 +10,27 @@ const stubs = {
   CIcon: true,
 };
 
-const plugins = [
-  mockPinia({
-    currentScenario: {
-      ...emptyScenario,
-      result: {
-        data: mockResultResponseData as ScenarioResultData,
-        fetchError: undefined,
-        fetchStatus: "success",
-      },
-    },
-  }, true, { stubActions: false }),
-];
-
 describe("costsTable", () => {
   it("should render costs table correctly, when cost basis is USD", async () => {
     const wrapper = await mountSuspended(CostsTable, {
-      global: { stubs, plugins },
-      props: { basis: CostBasis.USD },
+      global: {
+        stubs,
+        plugins: [
+          mockPinia({
+            currentScenario: {
+              ...emptyScenario,
+              result: {
+                data: mockResultResponseData as ScenarioResultData,
+                fetchError: undefined,
+                fetchStatus: "success",
+              },
+            },
+            preferences: {
+              costBasis: CostBasis.USD,
+            },
+          }, true, { stubActions: false }),
+        ],
+      },
     });
 
     let wrapperText = wrapper.text();
@@ -53,8 +56,24 @@ describe("costsTable", () => {
 
   it("should render costs table correctly, when cost basis is percent of GDP", async () => {
     const wrapper = await mountSuspended(CostsTable, {
-      global: { stubs, plugins },
-      props: { basis: CostBasis.PercentGDP },
+      global: {
+        stubs,
+        plugins: [
+          mockPinia({
+            currentScenario: {
+              ...emptyScenario,
+              result: {
+                data: mockResultResponseData as ScenarioResultData,
+                fetchError: undefined,
+                fetchStatus: "success",
+              },
+            },
+            preferences: {
+              costBasis: CostBasis.PercentGDP,
+            },
+          }, true, { stubActions: false }),
+        ],
+      },
     });
 
     const wrapperText = wrapper.text();

--- a/tests/unit/components/CostsTable.spec.ts
+++ b/tests/unit/components/CostsTable.spec.ts
@@ -3,36 +3,66 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 import type { ScenarioResultData } from "~/types/apiResponseTypes";
 import { emptyScenario, mockPinia } from "../mocks/mockPinia";
 import { mockResultResponseData } from "../mocks/mockResponseData";
+import { CostBasis } from "~/types/unitTypes";
+import { costAsPercentOfGdp } from "~/components/utils/formatters";
+
+const stubs = {
+  CIcon: true,
+};
+
+const plugins = [
+  mockPinia({
+    currentScenario: {
+      ...emptyScenario,
+      result: {
+        data: mockResultResponseData as ScenarioResultData,
+        fetchError: undefined,
+        fetchStatus: "success",
+      },
+    },
+  }, true, { stubActions: false }),
+];
 
 describe("costsTable", () => {
-  it("should render costs table correctly", async () => {
+  it("should render costs table correctly, when cost basis is USD", async () => {
     const wrapper = await mountSuspended(CostsTable, {
-      global: {
-        plugins: [
-          mockPinia(
-            {
-              currentScenario: {
-                ...emptyScenario,
-                result: {
-                  data: mockResultResponseData as ScenarioResultData,
-                  fetchError: undefined,
-                  fetchStatus: "success",
-                },
-              },
-            },
-            true,
-            false,
-          ),
-        ],
-      },
+      global: { stubs, plugins },
+      props: { basis: CostBasis.USD },
     });
 
-    const wrapperText = wrapper.text();
+    let wrapperText = wrapper.text();
+
+    expect(wrapperText).toContain("Expand all");
+    expect(wrapperText).not.toContain("Collapse all");
+
+    const expandButton = wrapper.find("button[aria-label='Expand costs table']");
+    await expandButton.trigger("click");
+
+    wrapperText = wrapper.text();
+
+    expect(wrapperText).not.toContain("Expand all");
+    expect(wrapperText).toContain("Collapse all");
 
     mockResultResponseData.costs[0].children.forEach((cost) => {
       expect(wrapperText).toContain(formatCurrency(cost.value));
       cost.children.forEach((subCost) => {
         expect(wrapperText).toContain(formatCurrency(subCost.value));
+      });
+    });
+  });
+
+  it("should render costs table correctly, when cost basis is percent of GDP", async () => {
+    const wrapper = await mountSuspended(CostsTable, {
+      global: { stubs, plugins },
+      props: { basis: CostBasis.PercentGDP },
+    });
+
+    const wrapperText = wrapper.text();
+
+    mockResultResponseData.costs[0].children.forEach((cost) => {
+      expect(wrapperText).toContain(costAsPercentOfGdp(cost.value, mockResultResponseData.gdp).toFixed(1));
+      cost.children.forEach((subCost) => {
+        expect(wrapperText).toContain(costAsPercentOfGdp(subCost.value, mockResultResponseData.gdp).toFixed(1));
       });
     });
   });


### PR DESCRIPTION
Contains these updates to the costs table:

* Can be expanded/collapsed
* The cost basis is controlled by the global cost basis toggle