### PR TITLE
Sort options in comparison modal scenario selection, if parameter is deemed 'ordered' by the metadata

### DIFF
--- a/components/CreateComparison.vue
+++ b/components/CreateComparison.vue
@@ -44,7 +44,7 @@
             <CIcon v-if="chosenAxisId === para.id" class="text-muted ms-2 cilx" icon="cilX" />
           </CButton>
         </div>
-        <div v-if="chosenAxisId && !chosenParameterAxis?.ordered && chosenParameterAxis?.parameterType !== TypeOfParameter.Numeric" class="mt-3">
+        <div v-if="chosenParameterAxis && chosenParameterAxis.parameterType !== TypeOfParameter.Numeric" class="mt-3">
           <CFormLabel :id="FORM_LABEL_ID" :for="FORM_LABEL_ID" class="fs-5 form-label">
             Compare baseline scenario
             <CTooltip

--- a/components/ScenarioSelect.vue
+++ b/components/ScenarioSelect.vue
@@ -44,16 +44,21 @@
 import VueSelect from "vue3-select-component";
 import type { Parameter } from "~/types/parameterTypes";
 import { MAX_SCENARIOS_COMPARED_TO_BASELINE } from "~/components/utils/comparisons";
+import { sortOptions } from "./utils/parameters";
 
 const { showFeedback, parameterAxis, labelId } = defineProps<{
   showFeedback: boolean
-  parameterAxis: Parameter | undefined
+  parameterAxis: Parameter
   labelId: string
 }>();
 
 const menuOpen = ref(false);
 
-const selected = defineModel("selected", { type: Array<string>, required: true });
+const selected = defineModel("selected", {
+  type: Array<string>,
+  required: true,
+  get: value => sortOptions(parameterAxis, value),
+});
 
 const { nonBaselineSelectOptions } = useScenarioOptions(() => parameterAxis);
 const { feedback } = useComparisonValidation(selected);

--- a/components/utils/parameters.ts
+++ b/components/utils/parameters.ts
@@ -1,4 +1,4 @@
-import type { ParameterOption } from "~/types/parameterTypes";
+import type { Parameter, ParameterOption } from "~/types/parameterTypes";
 import type { Option } from "vue3-select-component";
 
 export interface ParameterSelectOption extends Option<string> {
@@ -14,5 +14,26 @@ export const paramOptsToSelectOpts = (options: Array<ParameterOption>): Paramete
       label,
       description: description ?? "",
     };
+  });
+};
+
+const getIndexOfOption = (options: Array<ParameterOption> = [], optionId: string): number => {
+  return options.findIndex(option => option.id === optionId);
+};
+
+// If the parameter is ordered, sort the options based on their order in the metadata.
+export const sortOptions = (parameter: Parameter, optionsToSort: string[]) => {
+  if (parameter.parameterType === "numeric") {
+    return optionsToSort.sort((a, b) => {
+      return Number.parseInt(a) - Number.parseInt(b);
+    });
+  }
+
+  if (!parameter.ordered || parameter.options === undefined) {
+    return optionsToSort;
+  }
+
+  return optionsToSort.sort((a, b) => {
+    return getIndexOfOption(parameter.options, a) - getIndexOfOption(parameter.options, b);
   });
 };

--- a/components/utils/parameters.ts
+++ b/components/utils/parameters.ts
@@ -30,7 +30,7 @@ export const sortOptions = (parameter: Parameter, optionsToSort: string[]) => {
   }
 
   if (!parameter.ordered || parameter.options === undefined) {
-    // Special case for unordered parameters where a 'none' option exists: such parameters can be considered semi-ordered.
+    // Special case for unordered parameters where a 'none' option exists: such parameters can be considered semi-ordered and 'none' will be placed at the start.
     return optionsToSort.sort((a, b) => Number(b === "none") - Number(a === "none"));
   }
 

--- a/components/utils/parameters.ts
+++ b/components/utils/parameters.ts
@@ -30,7 +30,8 @@ export const sortOptions = (parameter: Parameter, optionsToSort: string[]) => {
   }
 
   if (!parameter.ordered || parameter.options === undefined) {
-    return optionsToSort;
+    // Special case for unordered parameters where a 'none' option exists: such parameters can be considered semi-ordered.
+    return optionsToSort.sort((a, b) => Number(b === "none") - Number(a === "none"));
   }
 
   return optionsToSort.sort((a, b) => {

--- a/tests/unit/components/CreateComparison.spec.ts
+++ b/tests/unit/components/CreateComparison.spec.ts
@@ -63,6 +63,12 @@ const getDiseaseButton = (axisOptionsEl: DOMWrapper<Element>) => {
   return diseaseButton;
 };
 
+const getVaccineButton = (axisOptionsEl: DOMWrapper<Element>) => {
+  const vaccineButton = axisOptionsEl.findAll("button")[3];
+  expect(vaccineButton.text()).toEqual("Global vaccine investment");
+  return vaccineButton;
+};
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
@@ -168,11 +174,21 @@ describe("create comparison button and modal", () => {
     const comboboxEl = getComboboxEl(wrapper);
     expect(comboboxEl.exists()).toBe(true);
     // Disease options are all pre-selected because there are fewer of them than MAX_COMPARISON_SCENARIOS
-    const selectedOptionsPills = wrapper.findAll("button.multi-value");
-    expect(selectedOptionsPills).toHaveLength(6);
-    expect(selectedOptionsPills.map(el => el.text())).toEqual(expect.arrayContaining(
+    const diseaseSelectedOptionsTags = wrapper.findAll("button.multi-value");
+    expect(diseaseSelectedOptionsTags).toHaveLength(6);
+    expect(diseaseSelectedOptionsTags.map(el => el.text())).toEqual(expect.arrayContaining(
       ["Covid-19 wild-type", "Covid-19 Omicron", "Covid-19 Delta", "Influenza 2009 (Swine flu)", "Influenza 1957", "Influenza 1918 (Spanish flu)"],
     ));
+
+    // Click the already-selected disease axis button to deselect it
+    await diseaseButton.trigger("click");
+
+    const vaccineButton = getVaccineButton(axisOptionsEl);
+    await vaccineButton.trigger("click");
+
+    // Vaccine options are pre-selected and listed in the same order as they are in metadata
+    const vaccineSelectedOptionsTags = wrapper.findAll("button.multi-value");
+    expect(vaccineSelectedOptionsTags.map(el => el.text())).toEqual(["Low", "Medium", "High"]);
   });
 
   it("renders the validation feedback as expected", async () => {

--- a/tests/unit/components/ScenarioSelect.spec.ts
+++ b/tests/unit/components/ScenarioSelect.spec.ts
@@ -20,7 +20,9 @@ const plugins = [mockPinia({
 }, false)];
 
 const controlSelector = ".value-container.multi";
-const pathogenParameter = mockMetadataResponseData.parameters.find(p => p.id === "pathogen");
+const pathogenParameter = mockMetadataResponseData.parameters.find(p => p.id === "pathogen")!;
+const responseParameter = mockMetadataResponseData.parameters.find(p => p.id === "response")!;
+const vaccineParameter = mockMetadataResponseData.parameters.find(p => p.id === "vaccine")!;
 
 const getOptionFromMenu = (wrapper: VueWrapper, optionText: string) => {
   const matcher = new RegExp(optionText, "i");
@@ -37,7 +39,7 @@ describe("scenario select", () => {
     const wrapper = mount(ScenarioSelect, {
       props: {
         showFeedback: false,
-        parameterAxis: mockMetadataResponseData.parameters.find(p => p.id === "response"),
+        parameterAxis: responseParameter,
         labelId: "formLabelId",
         selected: ["school_closures"],
       },
@@ -93,6 +95,32 @@ describe("scenario select", () => {
 
     expect(wrapper.props("selected")).toHaveLength(1);
     expect(wrapper.props("selected")).toEqual(expect.arrayContaining(["sars_cov_2_omicron"]));
+  });
+
+  it("can sort the v-model prop when the parameter metadata deems its options to have a defined order", async () => {
+    const wrapper = mount(ScenarioSelect, {
+      props: {
+        "showFeedback": false,
+        "parameterAxis": vaccineParameter,
+        "labelId": "formLabelId",
+        "selected": ["medium"],
+        "onUpdate:selected": (e: string[]) => wrapper.setProps({ selected: e }),
+      },
+      global: { stubs, plugins },
+    });
+
+    // Open menu
+    await wrapper.find(controlSelector).trigger("click");
+
+    // Select 'high' option
+    const highOption = getOptionFromMenu(wrapper, "high");
+    await highOption!.trigger("click");
+
+    // Select 'low' option
+    const lowOption = getOptionFromMenu(wrapper, "low");
+    await lowOption!.trigger("click");
+
+    expect(wrapper.props("selected")).toEqual(["low", "medium", "high"]);
   });
 
   it("initializes closed, opens when control is clicked, and stays open after selection is changed", async () => {

--- a/tests/unit/components/utils/parameters.spec.ts
+++ b/tests/unit/components/utils/parameters.spec.ts
@@ -55,4 +55,20 @@ describe("sortOptions", () => {
     const optionsToSort = ["1", "3", "2"];
     expect(sortOptions(parameter, optionsToSort)).toEqual(["1", "2", "3"]);
   });
+
+  it("should handle semi-ordered parameters by putting 'none' first", () => {
+    const parameter = {
+      id: "myUnorderedParameter",
+      ordered: false,
+      label: "My Unordered Parameter",
+      parameterType: TypeOfParameter.Select,
+      options: [
+        { id: "a", label: "Option A" },
+        { id: "none", label: "None" },
+        { id: "b", label: "Option B" },
+      ],
+    };
+    const optionsToSort = ["b", "none", "a"];
+    expect(sortOptions(parameter, optionsToSort)).toEqual(["none", "b", "a"]);
+  });
 });

--- a/tests/unit/components/utils/parameters.spec.ts
+++ b/tests/unit/components/utils/parameters.spec.ts
@@ -1,4 +1,5 @@
-import { paramOptsToSelectOpts } from "@/components/utils/parameters";
+import { paramOptsToSelectOpts, sortOptions } from "@/components/utils/parameters";
+import { TypeOfParameter } from "~/types/parameterTypes";
 
 describe("paramOptsToSelectOpts", () => {
   it("should convert from (metadata) parameter option type, to the option type required for selects", () => {
@@ -10,5 +11,48 @@ describe("paramOptsToSelectOpts", () => {
       { value: "a", label: "A", description: "Description of A" },
       { value: "b", label: "B", description: "" },
     ]);
+  });
+});
+
+describe("sortOptions", () => {
+  it("should return the same order if parameter is not deemed 'ordered' in its metadata", () => {
+    const parameter = {
+      id: "myUnorderedParameter",
+      ordered: false,
+      label: "My Unordered Parameter",
+      parameterType: TypeOfParameter.Select,
+      options: [
+        { id: "a", label: "Option A" },
+        { id: "b", label: "Option B" },
+      ],
+    };
+    const optionsToSort = ["b", "a"];
+    expect(sortOptions(parameter, optionsToSort)).toEqual(["b", "a"]);
+  });
+
+  it("should return the correct order if parameter is, in fact, ordered", () => {
+    const parameter = {
+      id: "myOrderedParameter",
+      ordered: true,
+      label: "My Ordered Parameter",
+      parameterType: TypeOfParameter.Select,
+      options: [
+        { id: "a", label: "Option A" },
+        { id: "b", label: "Option B" },
+      ],
+    };
+    const optionsToSort = ["b", "a"];
+    expect(sortOptions(parameter, optionsToSort)).toEqual(["a", "b"]);
+  });
+
+  it("should handle numeric parameters", () => {
+    const parameter = {
+      id: "myNumericParameter",
+      ordered: false,
+      label: "My Numeric Parameter",
+      parameterType: TypeOfParameter.Numeric,
+    };
+    const optionsToSort = ["1", "3", "2"];
+    expect(sortOptions(parameter, optionsToSort)).toEqual(["1", "2", "3"]);
   });
 });


### PR DESCRIPTION
Whether a parameter is 'ordered' is already configured in the metadata provided by the R API. E.g. the "none", "low", "medium" and "high" options for global vaccine investment clearly have an ordering to them. But the list of diseases doesn't have an ordering.

The idea is that this configuration should fix the order that options are displayed in the scenario select, both in terms of the 'tags'/'pills' within the control, and the options in the dropdown menu.

Relates to https://github.com/jameel-institute/daedalus.api/pull/38 in that that PR will update the API's metadata to make the 'response' parameter unordered.
