### PR TITLE
Refactor ParameterForm component

### DIFF
--- a/assets/scss/_theme.scss
+++ b/assets/scss/_theme.scss
@@ -135,41 +135,6 @@ body {
   padding-top: 0.25rem !important; // Equivalent to adding class 'pt-1'
 }
 
-// Restore radio button group styling to allow for buttons no longer being direct children of button groups - which is
-// required for tooltips to display
-.btn-group > {
-  .radio-btn-container {
-    flex-grow: 1;
-    .btn {
-      width: 100%;
-    }
-    &:not(:last-child) > {
-      .btn {
-        border-bottom-right-radius: 0 !important;
-        border-top-right-radius: 0 !important;
-        border-right-width: 0 !important;
-      }
-    }
-    &:not(:first-child) > {
-      .btn {
-        border-bottom-left-radius: 0 !important;
-        border-top-left-radius: 0 !important;
-      }
-    }
-  }
-}
-
-.btn-group-lg > {
-  .radio-btn-container > {
-    .btn {
-      --cui-btn-padding-y: .5rem;
-      --cui-btn-padding-x: 1rem;
-      --cui-btn-font-size: 1.25rem;
-      --cui-btn-border-radius: var(--cui-border-radius-lg);
-    }
-  }
-}
-
 // In vue-select parameter dropdowns, avoid highlighting both focused (used when navigating with keyboard) and
 // hovered menu items, by forcing the unhighlighted background colour on any menu item which has a sibling which
 // is hovered. This does not apply to the currently selected menu item (also highlighted, in a different colour).

--- a/components/ParameterNumericInput.vue
+++ b/components/ParameterNumericInput.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="d-flex numeric-header">
+    <ParameterHeader :parameter="props.parameter" />
+  </div>
+  <div class="d-flex flex-wrap">
+    <div class="flex-grow-1" :class="[warn && !invalid ? 'has-warning' : '']">
+      <CFormInput
+        :id="props.parameter.id"
+        v-model="parameterValue"
+        :aria-label="props.parameter.label"
+        type="number"
+        :class="[props.pulsing ? 'pulse' : '']"
+        :min="range?.min"
+        :max="range?.max"
+        :step="props.parameter.step"
+        :size="appStore.largeScreen ? 'lg' : undefined"
+        :feedback-invalid="tooltipText"
+        :data-valid="!invalid"
+        :invalid="showTooltip"
+        :tooltip-feedback="true"
+        @change="handleChange"
+        @input="handleInput"
+      />
+      <CFormRange
+        :id="props.parameter.id"
+        v-model="parameterValue"
+        :aria-label="props.parameter.label"
+        :step="props.parameter.step"
+        :min="range?.min"
+        :max="range?.max"
+        @change="handleChange"
+      />
+    </div>
+    <CButton
+      style="border: none;"
+      type="button"
+      color="secondary"
+      variant="ghost"
+      shape="rounded-pill"
+      :class="`${parameterValue === defaultValue ? 'invisible' : ''} btn-sm ms-2 align-self-start`"
+      :aria-label="`Reset ${props.parameter.label} to default`"
+      title="Reset to default"
+      @click="parameterValue = defaultValue"
+    >
+      <CIcon icon="cilActionUndo" size="sm" />
+    </CButton>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { CIcon } from "@coreui/icons-vue";
+
+import { type Parameter, type ParameterSet, TypeOfParameter } from "@/types/parameterTypes";
+// TODO: I'd like to refactor those utils into composables, to reduce the amount of data that needs to be passed around into the utils
+import { numericValueInvalid, numericValueIsOutOfRange } from "./utils/validations";
+import { debounce } from "perfect-debounce";
+import { getRangeForDependentParam } from "./utils/parameters";
+
+const props = defineProps<{
+  parameter: Parameter
+  parameterSet: ParameterSet
+  pulsing: boolean
+  showValidations: boolean
+}>();
+
+const emit = defineEmits(["change"]);
+
+const parameterValue = defineModel("parameterValue", { type: String });
+
+const appStore = useAppStore();
+
+const showWarnings = ref(false); // Show warning tooltip if there is any warning to show
+
+const handleChange = () => {
+  showWarnings.value = true;
+  emit("change");
+};
+
+const handleInput = () => {
+  // Stop showing warnings while the user is typing
+  showWarnings.value = false;
+
+  debounce(() => {
+    showWarnings.value = true;
+  }, 500)();
+};
+
+const range = computed(() => {
+  return getRangeForDependentParam(props.parameter, props.parameterSet);
+});
+
+// NB: Currently, due to the metadata schema, non-updatable numerics don't have default values available.
+const defaultValue = computed(() => range.value?.default.toString() || "");
+
+const invalid = computed(() => {
+  return (!parameterValue.value || numericValueInvalid(parameterValue.value, props.parameter));
+});
+
+const warn = computed(() => {
+  return numericValueIsOutOfRange(parameterValue.value, props.parameter, props.parameterSet);
+});
+
+const showTooltip = computed(() => !!(warn.value && showWarnings.value) || !!(invalid.value && props.showValidations));
+
+const tooltipText = computed(() => {
+  if (props.parameter.parameterType === TypeOfParameter.Numeric && invalid.value) {
+    return "Field cannot be empty or negative.";
+  } else if (props.parameter.updateNumericFrom && warn.value && !invalid.value) {
+    const dependedUponParam = appStore.parametersMetadataById[props.parameter.updateNumericFrom!.parameterId];
+
+    if (dependedUponParam) {
+      const selectedOption = dependedUponParam.options?.find((o) => {
+        return o.id === (props.parameterSet ?? {})[props.parameter.updateNumericFrom?.parameterId || ""];
+      });
+      return `NB: This value is outside the estimated range for ${selectedOption?.label} (${range.value?.min}–${range.value?.max}).`
+        + ` Proceed with caution.`;
+    }
+  }
+  return "This field is required.";
+});
+</script>
+
+<style scoped lang="scss">
+:deep(.has-warning input[type=range].form-range) {
+  &::-webkit-slider-thumb {
+    background-color: $warning;
+  }
+
+  &::-moz-range-thumb {
+    background-color: $warning;
+  }
+
+  &::-ms-thumb {
+    background-color: $warning;
+  }
+}
+</style>

--- a/components/ParameterRadio.vue
+++ b/components/ParameterRadio.vue
@@ -1,0 +1,93 @@
+<template>
+  <CRow class="pe-2">
+    <ParameterHeader :parameter="props.parameter" />
+  </CRow>
+  <CRow>
+    <CButtonGroup
+      role="group"
+      :aria-label="props.parameter.label"
+      :size="appStore.largeScreen ? 'lg' : undefined"
+      :class="`${props.pulsing ? 'pulse' : ''}`"
+      @change="$emit('change')"
+    >
+      <CTooltip
+        v-for="(option) in props.parameter.options"
+        :key="option.id"
+        :content="option.description"
+        placement="top"
+        :delay="100"
+      >
+        <template #toggler="{ togglerId, on }">
+          <div
+            class="radio-btn-container"
+            :aria-describedby="togglerId"
+            v-on="on"
+          >
+            <CFormCheck
+              :id="option.id"
+              v-model="parameterValue"
+              type="radio"
+              :button="{ color: 'primary', variant: 'outline' }"
+              :name="props.parameter.id"
+              autocomplete="off"
+              :label="option.label"
+              :value="option.id"
+            />
+          </div>
+        </template>
+      </CTooltip>
+    </CButtonGroup>
+  </CRow>
+</template>
+
+<script lang="ts" setup>
+import type { Parameter } from "@/types/parameterTypes";
+
+const props = defineProps<{
+  parameter: Parameter
+  pulsing: boolean
+}>();
+
+defineEmits(["change"]);
+
+const parameterValue = defineModel("parameterValue", { type: String, required: true });
+
+const appStore = useAppStore();
+</script>
+
+<style lang="scss">
+// Restore radio button group styling to allow for buttons no longer being direct children of button groups - which is
+// required for tooltips to display
+.btn-group > {
+  .radio-btn-container {
+    flex-grow: 1;
+    .btn {
+      width: 100%;
+    }
+    &:not(:last-child) > {
+      .btn {
+        border-bottom-right-radius: 0 !important;
+        border-top-right-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+    }
+    &:not(:first-child) > {
+      .btn {
+        border-bottom-left-radius: 0 !important;
+        border-top-left-radius: 0 !important;
+      }
+    }
+  }
+}
+
+.btn-group-lg > {
+  .radio-btn-container > {
+    .btn {
+      --cui-btn-padding-y: .5rem;
+      --cui-btn-padding-x: 1rem;
+      --cui-btn-font-size: 1.25rem;
+      --cui-btn-border-radius: var(--cui-border-radius-lg);
+    }
+  }
+}
+</style>

--- a/components/ParameterSelect.vue
+++ b/components/ParameterSelect.vue
@@ -1,0 +1,65 @@
+<template>
+  <CRow>
+    <ParameterHeader :parameter="parameter" />
+    <VueSelect
+      v-model="parameterValue"
+      :input-id="props.parameter.id"
+      :aria="{ labelledby: `${props.parameter.id}-label`, required: true }"
+      :class="`form-control ${props.pulsing ? 'pulse' : ''}`"
+      :options="paramOptsToSelectOpts(props.parameter.options || [])"
+      :is-clearable="false"
+      @option-selected="$emit('change')"
+    >
+      <template #value="{ option }">
+        <div class="d-flex gap-2 align-items-center">
+          <span
+            v-if="props.parameter === appStore.globeParameter && countryFlagIds?.[option.value]"
+            :class="`fi fi-${countryFlagIds[option.value]}`"
+          />
+          {{ option.label }}
+        </div>
+      </template>
+      <template #option="{ option }">
+        <div class="parameter-option">
+          <span
+            v-if="props.parameter === appStore.globeParameter && countryFlagIds?.[option.value]"
+            :class="`fi fi-${countryFlagIds[option.value]} ms-1`"
+          />
+          <span>{{ option.label }}</span>
+          <div
+            v-if="option.description"
+            :class="option.value === parameterValue ? 'text-dark' : 'text-muted'"
+          >
+            <small>{{ option.description }}</small>
+          </div>
+        </div>
+      </template>
+    </VueSelect>
+  </CRow>
+</template>
+
+<script lang="ts" setup>
+import VueSelect from "vue3-select-component";
+import { countryFlagIconId } from "~/components/utils/countryFlag";
+
+import { paramOptsToSelectOpts } from "~/components/utils/parameters";
+import type { Parameter } from "@/types/parameterTypes";
+
+const props = defineProps<{
+  parameter: Parameter
+  pulsing: boolean
+}>();
+
+defineEmits(["change"]);
+
+const parameterValue = defineModel("parameterValue", { type: String, required: true });
+
+const appStore = useAppStore();
+
+const countryFlagIds = computed(() => {
+  return appStore.globeParameter?.options?.reduce((acc, option) => {
+    acc[option.id] = countryFlagIconId(option.id) || "";
+    return acc;
+  }, {} as { [key: string]: string });
+});
+</script>


### PR DESCRIPTION
The ParameterForm component had grown to a silly size (492 lines) so I have split it up into a top-level component (ParameterForm) and three lower-level components (one for each of the types of inputs that the form renders, which depends on the parameter metadata provided by the R API service.) Thus, we now have a ParameterRadio component (which displays inputs that are functionally equivalent to radio buttons, even though they're actually displayed as a group of buttons), a ParameterSelect component (for select fields, such as country selection), and a ParameterNumericInput component.

This hopefully improves readability and encapsulation of related logic.

This PR shouldn't introduce new behaviour / logic. Thus I haven't added any unit tests for the lower-level components - these are implicitly tested by the existing tests, `ParameterForm.spec.ts`