### PR TITLE
Highlight the baseline scenario in column chart

### DIFF
--- a/components/CompareCostsChart.client.vue
+++ b/components/CompareCostsChart.client.vue
@@ -49,7 +49,9 @@ const getSeries = (): Highcharts.SeriesColumnOptions[] => {
       const costAsGdpPercent = costAsPercentOfGdp(dollarValue, scenario.result.data?.gdp);
       const y = costBasis.value === CostBasis.PercentGDP ? costAsGdpPercent : dollarValue;
       const name = appStore.getCostLabel(subCost?.id || "");
-      return { y, name, custom: { costAsGdpPercent } };
+      const opacity = scenario === appStore.baselineScenario ? 1 : 0.8;
+      const borderColor = scenario === appStore.baselineScenario ? "white" : "transparent";
+      return { y, name, custom: { costAsGdpPercent }, opacity, borderColor };
     }),
   } as Highcharts.SeriesColumnOptions)) || [];
 
@@ -86,8 +88,12 @@ const chartInitialOptions = () => {
       categories: scenarios.value?.map(s => appStore.getScenarioAxisValue(s)) || [],
       title: { text: appStore.axisLabel },
       labels: {
-        style: { fontSize: appStore.currentComparison.axis === appStore.globeParameter?.id ? "0.8rem" : "1rem" },
-        formatter() { return costsChartMultiScenarioXAxisLabelFormatter(this.value as string, axisMetadata.value); },
+        style: {
+          fontSize: appStore.currentComparison.axis === appStore.globeParameter?.id ? "0.8rem" : "1rem",
+        },
+        formatter() {
+          return costsChartMultiScenarioXAxisLabelFormatter(this.value as string, axisMetadata.value, appStore.currentComparison.baseline);
+        },
         useHTML: true,
       },
     },

--- a/components/utils/highCharts.ts
+++ b/components/utils/highCharts.ts
@@ -225,8 +225,15 @@ export const costsChartYAxisTickFormatter = (value: string | number, costBasis: 
   }
 };
 
-export const costsChartMultiScenarioXAxisLabelFormatter = (category: string, axisParam: Parameter | undefined) => {
-  const scenarioLabel = getScenarioCategoryLabel(category, axisParam);
+export const costsChartMultiScenarioXAxisLabelFormatter = (
+  category: string,
+  axisParam: Parameter | undefined,
+  baseline: string | undefined,
+) => {
+  let scenarioLabel = getScenarioCategoryLabel(category, axisParam);
+  if (baseline && category === baseline) {
+    scenarioLabel = `${scenarioLabel} (baseline)`;
+  }
 
   if (axisParam?.parameterType === TypeOfParameter.GlobeSelect) {
     return `<div class="d-flex gap-2 align-items-center mb-2">

--- a/tests/unit/components/CompareCostsChart.spec.ts
+++ b/tests/unit/components/CompareCostsChart.spec.ts
@@ -59,54 +59,103 @@ vi.mock("highcharts/esm/modules/exporting", () => ({}));
 vi.mock("highcharts/esm/modules/export-data", () => ({}));
 vi.mock("highcharts/esm/modules/offline-exporting", () => ({}));
 
+const pointOptionsForBaselineScenario = {
+  borderColor: "white",
+  opacity: 1,
+};
+const pointOptionsForComparisonScenario = {
+  borderColor: "transparent",
+  opacity: 0.8,
+};
+
 const expectedPercentGDPSeries = [
   expect.objectContaining({
     name: "GDP",
-    data: [expect.objectContaining({ name: "GDP", y: 32.87931628748886 }), expect.objectContaining({ name: "GDP", y: 0.050344764471232505 })],
+    data: [
+      expect.objectContaining({ name: "GDP", y: 32.87931628748886, ...pointOptionsForBaselineScenario }),
+      expect.objectContaining({ name: "GDP", y: 0.050344764471232505, ...pointOptionsForComparisonScenario }),
+    ],
   }),
   expect.objectContaining({
     name: "Education",
-    data: [expect.objectContaining({ name: "Education", y: 7.74667209175136 }), expect.objectContaining({ name: "Education", y: 0.10068952894246501 })],
+    data: [
+      expect.objectContaining({ name: "Education", y: 7.74667209175136, ...pointOptionsForBaselineScenario }),
+      expect.objectContaining({ name: "Education", y: 0.10068952894246501, ...pointOptionsForComparisonScenario }),
+    ],
   }),
   expect.objectContaining({
     name: "Life years",
-    data: [expect.objectContaining({ name: "Life years", y: 4.305661740495233 }), expect.objectContaining({ name: "Life years", y: expect.closeTo(0.151, 0.001) })],
+    data: [
+      expect.objectContaining({ name: "Life years", y: 4.305661740495233, ...pointOptionsForBaselineScenario }),
+      expect.objectContaining({ name: "Life years", y: expect.closeTo(0.151, 0.001), ...pointOptionsForComparisonScenario }),
+    ],
   }),
 ];
 
 const expectedUSDSeries = [
-  expect.objectContaining({ name: "GDP", data: [
-    expect.objectContaining({ name: "GDP", y: 6530831.2856, custom: {
-      costAsGdpPercent: 32.87931628748886,
-    } }),
-    expect.objectContaining({ name: "GDP", y: 10000, custom: {
-      costAsGdpPercent: 0.050344764471232505,
-    } }),
-  ] }),
-  expect.objectContaining({ name: "Education", data: [
-    expect.objectContaining({
-      name: "Education",
-      y: 1538724.4678,
-      custom: {
-        costAsGdpPercent: 7.74667209175136,
-      },
-    }),
-    expect.objectContaining({
-      name: "Education",
-      y: 20000,
-      custom: {
-        costAsGdpPercent: 0.10068952894246501,
-      },
-    }),
-  ] }),
-  expect.objectContaining({ name: "Life years", data: [
-    expect.objectContaining({ name: "Life years", y: 855235.2535, custom: {
-      costAsGdpPercent: 4.305661740495233,
-    } }),
-    expect.objectContaining({ name: "Life years", y: 30000, custom: {
-      costAsGdpPercent: expect.closeTo(0.151, 0.001),
-    } }),
-  ] }),
+  expect.objectContaining({
+    name: "GDP",
+    data: [
+      expect.objectContaining({
+        name: "GDP",
+        y: 6530831.2856,
+        custom: {
+          costAsGdpPercent: 32.87931628748886,
+        },
+        ...pointOptionsForBaselineScenario,
+      }),
+      expect.objectContaining({
+        name: "GDP",
+        y: 10000,
+        custom: {
+          costAsGdpPercent: 0.050344764471232505,
+        },
+        ...pointOptionsForComparisonScenario,
+      }),
+    ],
+  }),
+  expect.objectContaining({
+    name: "Education",
+    data: [
+      expect.objectContaining({
+        name: "Education",
+        y: 1538724.4678,
+        custom: {
+          costAsGdpPercent: 7.74667209175136,
+        },
+        ...pointOptionsForBaselineScenario,
+      }),
+      expect.objectContaining({
+        name: "Education",
+        y: 20000,
+        custom: {
+          costAsGdpPercent: 0.10068952894246501,
+        },
+        ...pointOptionsForComparisonScenario,
+      }),
+    ],
+  }),
+  expect.objectContaining({
+    name: "Life years",
+    data: [
+      expect.objectContaining({
+        name: "Life years",
+        y: 855235.2535,
+        custom: {
+          costAsGdpPercent: 4.305661740495233,
+        },
+        ...pointOptionsForBaselineScenario,
+      }),
+      expect.objectContaining({
+        name: "Life years",
+        y: 30000,
+        custom: {
+          costAsGdpPercent: expect.closeTo(0.151, 0.001),
+        },
+        ...pointOptionsForComparisonScenario,
+      }),
+    ],
+  }),
 ];
 
 describe("costs chart", () => {

--- a/tests/unit/components/utils/highCharts.spec.ts
+++ b/tests/unit/components/utils/highCharts.spec.ts
@@ -179,7 +179,7 @@ describe("costsChartLabelFormatter", () => {
 });
 
 describe("costsChartMultiScenarioXAxisLabelFormatter", () => {
-  it("should return the correct label for a country parameter", () => {
+  it("should return the correct label for a (non-baseline) country parameter", () => {
     const axisParam = {
       id: "country",
       label: "Country",
@@ -191,9 +191,10 @@ describe("costsChartMultiScenarioXAxisLabelFormatter", () => {
       ordered: false,
     };
 
-    const label = costsChartMultiScenarioXAxisLabelFormatter("USA", axisParam);
+    const label = costsChartMultiScenarioXAxisLabelFormatter("USA", axisParam, "CAN");
     expect(label).toContain('<span class="fi fi-us" style="width: 1.2rem; height: 1.2rem"></span>');
     expect(label).toContain("United States");
+    expect(label).not.toContain("baseline");
   });
 
   it("should return the correct label for a non-country parameter", () => {
@@ -223,6 +224,56 @@ describe("costsChartMultiScenarioXAxisLabelFormatter", () => {
 
     const label = costsChartMultiScenarioXAxisLabelFormatter("12345", axisParam);
     expect(label).toContain("12,345");
+  });
+
+  it("should return the correct label for a baseline scenario", () => {
+    const axisParam = {
+      id: "vaccine",
+      label: "Vaccine",
+      parameterType: TypeOfParameter.Select,
+      options: [
+        { id: "high", label: "High" },
+        { id: "low", label: "Low" },
+      ],
+      ordered: false,
+    };
+
+    const label = costsChartMultiScenarioXAxisLabelFormatter("high", axisParam, "high");
+    expect(label).toContain("High (baseline)");
+  });
+
+  it("should return the correct label for a non-baseline scenario", () => {
+    const axisParam = {
+      id: "vaccine",
+      label: "Vaccine",
+      parameterType: TypeOfParameter.Select,
+      options: [
+        { id: "high", label: "High" },
+        { id: "low", label: "Low" },
+      ],
+      ordered: false,
+    };
+
+    const label = costsChartMultiScenarioXAxisLabelFormatter("high", axisParam, "low");
+    expect(label).toContain("High");
+    expect(label).not.toContain("baseline");
+  });
+
+  it("should return the correct label for a baseline country scenario", () => {
+    const axisParam = {
+      id: "country",
+      label: "Country",
+      parameterType: TypeOfParameter.GlobeSelect,
+      options: [
+        { id: "USA", label: "United States" },
+        { id: "CAN", label: "Canada" },
+      ],
+      ordered: false,
+    };
+
+    const label = costsChartMultiScenarioXAxisLabelFormatter("USA", axisParam, "USA");
+    expect(label).toContain('<span class="fi fi-us" style="width: 1.2rem; height: 1.2rem"></span>');
+    expect(label).toContain("United States (baseline)");
   });
 });
 


### PR DESCRIPTION
The baseline scenario will be denoted / highlighted by:
- Different border color for column (white vs transparent)
- Different opacity (baseline scenario is 100% opaque)
- Noted in the x-axis label as '(baseline)'