### PR TITLE
Fix error message about missing Nuxt instance

### DIFF
--- a/pages/comparison.vue
+++ b/pages/comparison.vue
@@ -167,6 +167,7 @@ import type { Scenario } from "~/types/storeTypes";
 
 const showSpinner = ref(true);
 
+const nuxtApp = useNuxtApp();
 const appStore = useAppStore();
 const { everyScenarioHasRunSuccessfully } = storeToRefs(appStore);
 const query = useRoute().query;
@@ -194,7 +195,9 @@ watch(() => appStore.metadata, async (newMetadata) => {
 
 const stopWatchingComparison = watch(() => appStore.currentComparison, async (currentComp) => {
   if (!statusInterval && appStore.everyScenarioHasARunId) {
-    statusInterval = setInterval(appStore.refreshComparisonStatuses, 200);
+    statusInterval = setInterval(() => {
+      appStore.refreshComparisonStatuses(nuxtApp);
+    }, 200);
   }
   if (currentComp.scenarios?.every(s => s.status.data?.done)) {
     clearInterval(statusInterval);

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -203,7 +203,6 @@ export const useAppStore = defineStore("app", {
 
       const { data, status, error } = await useFetch(
         `/api/scenarios/${scenario.runId}/result`,
-        { dedupe: "defer" },
       ) as {
         data: Ref<ScenarioResultData>
         status: Ref<AsyncDataRequestStatus>

--- a/stores/appStore.ts
+++ b/stores/appStore.ts
@@ -1,4 +1,4 @@
-import type { AsyncDataRequestStatus } from "#app";
+import type { AsyncDataRequestStatus, NuxtApp } from "#app";
 import type { Metadata, NewScenarioData, ScenarioData, ScenarioResultData, ScenarioStatusData, TimeSeriesGroup, VersionData } from "~/types/apiResponseTypes";
 import type { AppState, Comparison, Scenario } from "@/types/storeTypes";
 import type { FetchError } from "ofetch";
@@ -265,10 +265,12 @@ export const useAppStore = defineStore("app", {
         }) || [],
       );
     },
-    async refreshComparisonStatuses() {
-      await Promise.all(this.currentComparison.scenarios?.map(async (scenario) => {
-        await this.refreshScenarioStatus(scenario);
-      }) || []);
+    async refreshComparisonStatuses(nuxtInstance: NuxtApp) {
+      nuxtInstance.runWithContext(async () => {
+        await Promise.all(this.currentComparison.scenarios?.map(async (scenario) => {
+          await this.refreshScenarioStatus(scenario);
+        }) || []);
+      });
     },
     async loadComparisonResults() {
       await Promise.all(this.currentComparison.scenarios?.map(async (scenario) => {

--- a/tests/unit/stores/appStore.spec.ts
+++ b/tests/unit/stores/appStore.spec.ts
@@ -270,6 +270,8 @@ describe("app store", () => {
     it("can retrieve a comparison's scenarios' statuses from the R API", async () => {
       const store = useAppStore();
 
+      const nuxtApp = useNuxtApp();
+
       store.currentComparison = structuredClone({
         axis: "vaccine",
         baseline: "high",
@@ -292,7 +294,7 @@ describe("app store", () => {
         ],
       });
 
-      await store.refreshComparisonStatuses();
+      await store.refreshComparisonStatuses(nuxtApp);
 
       await waitFor(() => {
         expect(store.currentComparison.scenarios.find(s => s.runId === "123")?.status).toEqual({


### PR DESCRIPTION
## First commit

"[Provide nuxt context explicitly when refreshing statuses server-side](https://github.com/jameel-institute/daedalus-web-app/commit/aa8a96569cec8c478e23836f90bacc56865d915a)"

See [https://nuxt.com/docs/4.x/api/composables/use-nuxt-app\#runwithcontext](https://nuxt.com/docs/4.x/api/composables/use-nuxt-app/#runwithcontext)

This change is to prevent an error (really a warning, since everything continued to work as expected) that was thrown whenever a comparison page was loaded on the server side. The error message is reproduced below.

I infer that it was caused by awaited calls to store method refreshScenarioStatus that did not have access to the nuxt context (as the docs above say, Nuxt/Vue drop context when doing awaits, in order to prevent shared state between different users' requests during SSR). I didn't want to solve the problem by switching to using dollar-fetch instead of useFetch, as that would mean preventing the calls from ever running on the server side (that's the point of using useFetch). So we manage the context explicitly, allowing it to be provided for the store method.

```
ERROR  [unhandledRejection] [nuxt] A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug. Find out more at [https://nuxt.com/docs/guide/concepts/auto-imports\#vue-and-nuxt-composables](https://nuxt.com/docs/guide/concepts/auto-imports/#vue-and-nuxt-composables).

    at useNuxtApp (node_modules/nuxt/dist/app/nuxt.js:251:13)
    at useAsyncData (node_modules/nuxt/dist/app/composables/asyncData.js:30:55)
    at useFetch (node_modules/nuxt/dist/app/composables/fetch.js:57:59)
    at Proxy.refreshScenarioStatus (stores/appStore.ts:164:58)
    at Proxy.wrappedAction (node_modules/pinia/dist/pinia.mjs:1083:18)
    at stores/appStore.ts:230:20
    at wrappedFn (node_modules/@vue/reactivity/dist/reactivity.cjs.js:861:19)
    at Array.map (<anonymous>)
    at apply (node_modules/@vue/reactivity/dist/reactivity.cjs.js:869:27)
    at Proxy.map (node_modules/@vue/reactivity/dist/reactivity.cjs.js:793:12)
```

NB - an alternative solution to passing the Nuxt context explicitly would be to wrap the calls into a composable, as per the suggestion at https://github.com/vuejs/pinia/discussions/2245. I haven't tested this approach - it would be a larger change. The theory behind it is that composables automatically provide the Nuxt context.

## Second commit

[Dedupe results requests with default 'cancel' behaviour, not dedupe](https://github.com/jameel-institute/daedalus-web-app/commit/74b8fd28cc4728ae9b245300b761779f3f21b5c1)

> We changed dedupe behaviour from 'cancel' to 'defer' in https://github.com/jameel-institute/daedalus-web-app/pull/89

> This solves a real problem for status requests, which poll, but results requests only happen once, so the default 'cancel' behaviour is more appropriate.

## Manually testing this branch

Verify that everything still works as before by running the app, creating a comparison, and then refreshing the page to force it to be rendered server side. Check that no error is logged in the terminal.

To be sure that the app works under conditions of slow internet, use the developer tools to simulate a slow network.