### PR TITLE
Bugfix for Globe

### DIFF
--- a/components/Globe.vue
+++ b/components/Globe.vue
@@ -128,7 +128,7 @@ const prevSelectablePolygon = ref<am5map.MapPolygon | undefined>(undefined);
 const findFeatureForCountry = (countryIso: string) => WHONationalBorders.features.find(f => f.id === countryIso);
 
 const highlightedCountrySeries = computed(() => {
-  if (!appStore.globe.highlightedCountry) {
+  if (!appStore.globe.highlightedCountry || !selectableCountriesSeries) {
     return null;
   };
   // If the corresponding feature of the countrySeries has the state 'hover', then start from the midPoint color
@@ -317,7 +317,7 @@ const highlightCountry = async () => {
   }
 };
 
-watch(() => highlightedCountrySeries.value, async (newSeries, oldSeries) => {
+watch(highlightedCountrySeries, async (newSeries, oldSeries) => {
   if (chart) {
     prevSelectablePolygon.value?.set("active", false);
     if (!appStore.globe.highlightedCountry) {


### PR DESCRIPTION
Occasionally, due to a missing `selectableCountriesSeries`, the Globe would throw an error, which would prevent a page navigation from happening. I'm not sure why it goes missing - presumably there is some race condition - but this makes the app more usable in that we don't want to prevent navigations just because the globe (which is decorative) has something wrong with it.