### PR TITLE
J-IDEA 294: Dotted capacity lines

### DIFF
--- a/components/CapacitiesAndInterventionsLegend.vue
+++ b/components/CapacitiesAndInterventionsLegend.vue
@@ -20,7 +20,7 @@ const plotLineItems = computed(() => {
     return [];
   }
   return appStore.metadata?.results.capacities.map((capacity) => {
-    return { color: plotLinesColor, label: capacity.label, shape: LegendShape.Line };
+    return { color: plotLinesColor, label: capacity.label, shape: LegendShape.SquareDash };
   }) ?? [];
 });
 

--- a/components/ChartLegend.client.vue
+++ b/components/ChartLegend.client.vue
@@ -3,9 +3,23 @@
     <div
       v-for="item in items"
       :key="item.label"
-      :class="`legend-item legend-item-${item.shape}`"
+      class="legend-item"
     >
-      <i :style="iStyle(item)" />
+      <!-- The svg is modelled after the plot-line graphic used in the Highcharts chart -->
+      <svg
+        v-if="item.shape === LegendShape.SquareDash"
+        :width="iWidthPx"
+        :height="plotLinesWidthPx"
+        :style="{ marginTop: lineMarginTop }"
+      >
+        <path
+          :stroke="item.color"
+          :stroke-width="plotLinesWidthPx * 2"
+          :stroke-dasharray="`${plotLinesWidthPx},${plotLinesWidthPx}`"
+          :d="`M 0 0 L ${iWidthPx} 0`"
+        />
+      </svg>
+      <i v-else :style="iStyle(item)" />
       <span
         :style="{ lineHeight: `${props.rowHeightRem}rem` }"
       >
@@ -17,30 +31,37 @@
 
 <script setup lang="ts">
 import { type LegendItem, LegendShape } from "./utils/charts";
+import { plotLinesWidthPx } from "./utils/timeSeriesCharts";
 
 const props = defineProps<{
   items: LegendItem[]
   rowHeightRem: number
 }>();
 
+// Width of the i element should be an odd-numbered multiple of plotLinesWidthPx to ensure dotted svg paths start and finish
+// with dots rather than gap, aligning them visually with non-dotted legend items.
+const iWidthPx = 19 * plotLinesWidthPx;
 const lineHeightRem = 0.15;
+const lineMarginTop = `${(props.rowHeightRem / 2) - (lineHeightRem / 2)}rem`;
 
 const iStyle = (item: LegendItem) => {
   const style = {
     background: item.color,
+    width: `${iWidthPx}px`,
   };
   if (item.shape === LegendShape.Line) {
     return {
       ...style,
       height: `${lineHeightRem}rem`,
-      marginTop: `${(props.rowHeightRem / 2) - lineHeightRem}rem`,
+      marginTop: lineMarginTop,
     };
   } else if (item.shape === LegendShape.Circle) {
+    const circleDiameter = "11px";
     return {
       ...style,
       borderRadius: "50%",
-      height: `${props.rowHeightRem / 1.3}rem`,
-      width: `${props.rowHeightRem / 1.3}rem`,
+      height: circleDiameter,
+      width: circleDiameter,
     };
   } else if (item.shape === LegendShape.Rectangle) {
     return {
@@ -67,7 +88,6 @@ const iStyle = (item: LegendItem) => {
   }
 
   i {
-    width: 2.5rem;
     float: left;
   }
 }

--- a/components/utils/charts.ts
+++ b/components/utils/charts.ts
@@ -78,6 +78,7 @@ export enum LegendShape {
   Rectangle = "rectangle",
   Line = "line",
   Circle = "circle",
+  SquareDash = "squareDash",
 }
 
 export const contextButtonOptions = {

--- a/components/utils/timeSeriesCharts.ts
+++ b/components/utils/timeSeriesCharts.ts
@@ -3,6 +3,8 @@ import { humanReadableInteger } from "./formatters";
 
 export const plotLinesColorName = "Red";
 export const plotLinesColor = colorBlindSafeLargePalette.find(c => c.name === plotLinesColorName)!.rgb;
+export const plotLinesWidthPx = 2;
+
 export const plotBandsRgbAlpha = 0.3;
 export const plotBandsColorName = "Cyan";
 export const plotBandsDefaultColor = colorBlindSafeLargePalette.find(c => c.name === plotBandsColorName)!.rgb;

--- a/composables/useCapacitiesPlotLines.ts
+++ b/composables/useCapacitiesPlotLines.ts
@@ -1,5 +1,5 @@
 import { humanReadableInteger } from "~/components/utils/formatters";
-import { plotLinesColor } from "~/components/utils/timeSeriesCharts";
+import { plotLinesColor, plotLinesWidthPx } from "~/components/utils/timeSeriesCharts";
 import type { TimeSeriesCapacity } from "~/types/dataTypes";
 
 export default (
@@ -22,7 +22,8 @@ export default (
           },
           align: "middle",
         },
-        width: 2,
+        dashStyle: "ShortDot",
+        width: plotLinesWidthPx,
         value,
         zIndex: 4, // Render label in front of the series line
         id,

--- a/tests/unit/components/CapacitiesAndInterventionsLegend.spec.ts
+++ b/tests/unit/components/CapacitiesAndInterventionsLegend.spec.ts
@@ -26,13 +26,14 @@ describe("time series", () => {
       props: { showPlotLines: true },
     });
 
-    const squareItem = component.find(".legend-item-rectangle");
-    expect(squareItem.text()).toContain("Pandemic response");
-    expect(squareItem.element.outerHTML).toContain("background: rgba(51, 187, 238, 0.3)");
+    const legendItems = component.findAll(".legend-item");
+    const plotBandsLegendItem = legendItems[0];
+    expect(plotBandsLegendItem.text()).toContain("Pandemic response");
+    expect(plotBandsLegendItem.element.outerHTML).toContain("background: rgba(51, 187, 238, 0.3)");
 
-    const lineItem = component.find(".legend-item-line");
-    expect(lineItem.text()).toContain("Hospital surge capacity");
-    expect(lineItem.element.outerHTML).toContain("background: rgb(204, 51, 17)");
+    const plotLinesLegendItem = legendItems[1];
+    expect(plotLinesLegendItem.text()).toContain("Hospital surge capacity");
+    expect(plotLinesLegendItem.find("svg").element.outerHTML).toContain("rgb(204,51,17)");
   });
 
   it("should not render the intervention plot bands if the current scenario does not involve interventions", async () => {
@@ -43,11 +44,10 @@ describe("time series", () => {
       props: { showPlotLines: true },
     });
 
-    const lineItem = component.find(".legend-item-line");
-    expect(lineItem.text()).toContain("Hospital surge capacity");
+    const plotLinesLegendItem = component.find(".legend-item");
+    expect(plotLinesLegendItem.text()).toContain("Hospital surge capacity");
 
-    const squareItem = component.find(".legend-item-rectangle");
-    expect(squareItem.exists()).toBe(false);
+    expect(component.findAll(".legend-item")).toHaveLength(1);
   });
 
   it("should render the correct labels for the plot lines and plot bands when dealing with multiple scenarios", async () => {
@@ -64,13 +64,14 @@ describe("time series", () => {
       props: { showPlotLines: true },
     });
 
-    const squareItem = component.find(".legend-item-rectangle");
-    expect(squareItem.text()).toContain("Pandemic response");
-    expect(squareItem.element.outerHTML).toContain("background: rgba(238, 119, 51, 0.3)");
+    const legendItems = component.findAll(".legend-item");
+    const plotBandsLegendItem = legendItems[0];
+    expect(plotBandsLegendItem.text()).toContain("Pandemic response");
+    expect(plotBandsLegendItem.element.outerHTML).toContain("background: rgba(238, 119, 51, 0.3)");
 
-    const lineItem = component.find(".legend-item-line");
-    expect(lineItem.text()).toContain("Hospital surge capacity");
-    expect(lineItem.element.outerHTML).toContain("background: rgb(204, 51, 17)");
+    const plotLinesLegendItem = legendItems[1];
+    expect(plotLinesLegendItem.text()).toContain("Hospital surge capacity");
+    expect(plotLinesLegendItem.find("svg").element.outerHTML).toContain("rgb(204,51,17)");
   });
 
   it("should not render the plot lines label when props say not to", async () => {
@@ -87,7 +88,9 @@ describe("time series", () => {
       props: { showPlotLines: false },
     });
 
-    const lineItem = component.find(".legend-item-line");
-    expect(lineItem.exists()).toBe(false);
+    const plotBandsLegendItem = component.find(".legend-item");
+    expect(plotBandsLegendItem.text()).toContain("Pandemic response");
+
+    expect(component.findAll(".legend-item")).toHaveLength(1);
   });
 });

--- a/tests/unit/components/ChartLegend.spec.ts
+++ b/tests/unit/components/ChartLegend.spec.ts
@@ -4,6 +4,8 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 const items = [
   { label: "Item 1", shape: "rectangle", color: "rgb(0, 0, 100)" },
   { label: "Item 2", shape: "line", color: "rgba(0, 0, 100, 0.4)" },
+  { label: "Item 3", shape: "circle", color: "rgb(100, 0, 0)" },
+  { label: "Item 4", shape: "squareDash", color: "rgb(0, 100, 0)" },
 ];
 
 describe("chart legend", () => {
@@ -16,18 +18,39 @@ describe("chart legend", () => {
     expect(legendItems.length).toBe(items.length);
 
     items.forEach((item, index) => {
-      const legendItem = legendItems.at(index);
-      expect(legendItem?.text()).toContain(item.label);
-      expect(legendItem?.classes()).toContain(`legend-item-${item.shape}`);
+      console.error(item.shape);
 
-      const icon = legendItem?.find("i");
-      expect(icon?.attributes("style")).toContain(`background: ${item.color}`);
+      const legendItem = legendItems.at(index);
+      expect(legendItem!.text()).toContain(item.label);
+      expect(legendItem!.classes()).toContain(`legend-item`);
+
+      const icon = legendItem!.find("i");
+      const svg = legendItem!.find("svg");
       if (item.shape === "rectangle") {
+        expect(legendItem!.findAll("svg")).toHaveLength(0);
+        expect(icon?.attributes("style")).toContain(`background: ${item.color}`);
         expect(icon?.attributes("style")).toContain("height: 1rem");
-        expect(icon?.attributes("style")).not.toContain("margin-top: 0.35rem");
+        expect(icon?.attributes("style")).toContain("width: 38px");
       } else if (item.shape === "line") {
+        expect(legendItem!.findAll("svg")).toHaveLength(0);
+        expect(icon?.attributes("style")).toContain(`background: ${item.color}`);
         expect(icon?.attributes("style")).toContain("height: 0.15rem");
-        expect(icon?.attributes("style")).toContain("margin-top: 0.35rem");
+        expect(icon?.attributes("style")).toContain("margin-top: 0.425rem");
+        expect(icon?.attributes("style")).toContain("width: 38px");
+      } else if (item.shape === "circle") {
+        expect(legendItem!.findAll("svg")).toHaveLength(0);
+        expect(icon?.attributes("style")).toContain(`background: ${item.color}`);
+        expect(icon?.attributes("style")).toContain("border-radius: 50%");
+        expect(icon?.attributes("style")).toContain("height: 11px");
+      } else if (item.shape === "squareDash") {
+        expect(legendItem!.findAll("i")).toHaveLength(0);
+        expect(svg?.attributes("width")).toBe("38");
+        expect(svg?.attributes("height")).toBe("2");
+        expect(svg?.attributes("style")).toContain("margin-top: 0.425rem");
+        const path = svg?.find("path");
+        expect(path?.attributes("stroke")).toBe(item.color);
+        expect(path?.attributes("d")).toContain("38");
+        expect(path?.attributes("stroke-dasharray")).toBe("2,2");
       }
     });
   });

--- a/tests/unit/components/CompareTimeSeriesLegend.spec.ts
+++ b/tests/unit/components/CompareTimeSeriesLegend.spec.ts
@@ -32,13 +32,13 @@ describe("time series", () => {
 
     expect(component.text()).toContain("Scenarios by response");
 
-    const lineItems = component.findAll(".legend-item-line");
+    const legendItems = component.findAll(".legend-item");
 
-    expect(lineItems[0].text()).toContain("No closures");
-    expect(lineItems[0].text()).not.toContain("baseline");
-    expect(lineItems[0].element.outerHTML).toContain("background: rgb(238, 51, 119)");
+    expect(legendItems[0].text()).toContain("No closures");
+    expect(legendItems[0].text()).not.toContain("baseline");
+    expect(legendItems[0].element.outerHTML).toContain("background: rgb(238, 51, 119)");
 
-    expect(lineItems[1].text()).toMatch(/Business closures\s+\(baseline\)/);
-    expect(lineItems[1].element.outerHTML).toContain("background: rgb(238, 119, 51)");
+    expect(legendItems[1].text()).toMatch(/Business closures\s+\(baseline\)/);
+    expect(legendItems[1].element.outerHTML).toContain("background: rgb(238, 119, 51)");
   });
 });


### PR DESCRIPTION
Use dotted (really, short-dashed) lines for capacities on time series.

This is to help distinguish between series lines vs 'plot lines' showing capacities.

This required updates to the legend component to be able to display dotted lines in the same style as the chart.

<img width="860" height="403" alt="image" src="https://github.com/user-attachments/assets/aa80544d-dff6-4a65-909b-2aa57ef93028" />
