### PR TITLE
Rephrase references to 2018 GDP data source

### DIFF
--- a/components/CostBasisToggler.vue
+++ b/components/CostBasisToggler.vue
@@ -20,14 +20,14 @@
       >
         <template #label>
           <span>
-            in {{ gdpReferenceYear }} USD
+            in USD
             <TooltipHelp
               :help-text="gdpVariesByScenario
                 ? undefined
-                : `USD values based on ${gdpReferenceYear} GDP of ${scenarioGdpLabel(scenarios[0])}`
+                : `These USD values assume a pre-pandemic GDP of ${scenarioGdpLabel(scenarios[0])}, based on ${gdpReferenceYear} data.`
               "
               :list-header="gdpVariesByScenario
-                ? `USD values based on ${gdpReferenceYear} GDPs:`
+                ? `These USD values assume the following pre-pandemic GDPs, which are based on ${gdpReferenceYear} data:`
                 : undefined"
               :list-items="gdpVariesByScenario
                 ? scenarios.map((s) => `${scenarioLabel(s)}: ${scenarioGdpLabel(s)}`)

--- a/components/CostsTable.vue
+++ b/components/CostsTable.vue
@@ -27,7 +27,7 @@
               </span>
               <div v-else>
                 <span class="boldish">
-                  $, millions ({{ gdpReferenceYear }} USD)
+                  $, millions (USD)
                 </span>
               </div>
             </template>
@@ -106,7 +106,7 @@
 
 <script lang="ts" setup>
 import { CIcon } from "@coreui/icons-vue";
-import { costAsPercentOfGdp, gdpReferenceYear, humanReadableInteger, humanReadablePercentOfGdp } from "./utils/formatters";
+import { costAsPercentOfGdp, humanReadableInteger, humanReadablePercentOfGdp } from "./utils/formatters";
 import { CostBasis } from "~/types/unitTypes";
 import type { Scenario } from "~/types/storeTypes";
 

--- a/components/utils/costCharts.ts
+++ b/components/utils/costCharts.ts
@@ -1,5 +1,5 @@
 import { abbreviateMillionsDollars } from "~/utils/money";
-import { costAsPercentOfGdp, gdpReferenceYear, humanReadablePercentOfGdp } from "~/components/utils/formatters";
+import { costAsPercentOfGdp, humanReadablePercentOfGdp } from "~/components/utils/formatters";
 import { CostBasis } from "~/types/unitTypes";
 import { type Parameter, TypeOfParameter } from "~/types/parameterTypes";
 import { countryFlagClass } from "./countryFlag";
@@ -11,7 +11,7 @@ export const costsChartPalette = colorBlindSafeSmallPalette;
 export const costsChartYAxisTitle = (costBasis: CostBasis) => {
   return costBasis === CostBasis.PercentGDP
     ? `Losses as % of GDP`
-    : `Losses in billions ${gdpReferenceYear} USD`;
+    : `Losses in billions USD`;
 };
 
 const costsChartTooltipPointFormatter = (point: TooltipPointInstance, costBasis: CostBasis) => {
@@ -39,7 +39,7 @@ export const costsChartSingleScenarioTooltip = (context: unknown, costBasis: Cos
     headerText = `${headerText}<b>${percentOfGdp.percent}%</b> ${percentOfGdp.reference}`;
   } else {
     const abbreviatedTotal = abbreviateMillionsDollars(tooltipPointInstance.total);
-    headerText = `${headerText}<b>$${abbreviatedTotal.amount} ${abbreviatedTotal.unit}</b> ${gdpReferenceYear} USD`;
+    headerText = `${headerText}<b>$${abbreviatedTotal.amount} ${abbreviatedTotal.unit}</b> USD`;
     if (tooltipPointInstance.total > 0) {
       const percentOfGdp = humanReadablePercentOfGdp(costAsPercentOfGdp(tooltipPointInstance.total, nationalGdp));
       headerText = `${headerText}</br>(${percentOfGdp.percent}% ${percentOfGdp.reference})`;
@@ -71,7 +71,7 @@ export const costsChartMultiScenarioStackedTooltip = (context: unknown, costBasi
     headerText = `${headerText}</br></br>Total losses: <b>${percentOfGdp.percent}%</b> ${percentOfGdp.reference}`;
   } else {
     const abbreviatedTotal = abbreviateMillionsDollars(point.total);
-    headerText = `${headerText}<br/></br>Total losses: <b>$${abbreviatedTotal.amount} ${abbreviatedTotal.unit}</b> ${gdpReferenceYear} USD`;
+    headerText = `${headerText}<br/></br>Total losses: <b>$${abbreviatedTotal.amount} ${abbreviatedTotal.unit}</b> USD`;
     if (point.total > 0) {
       const totalCostAsGdpPercent = point.points?.map(p => p.custom.costAsGdpPercent).reduce((sum, a) => sum + a, 0);
       if (totalCostAsGdpPercent) {

--- a/tests/unit/components/CompareCostsChart.spec.ts
+++ b/tests/unit/components/CompareCostsChart.spec.ts
@@ -161,7 +161,7 @@ describe("costs chart", () => {
     },
     {
       costBasis: CostBasis.USD,
-      yAxisTitle: "Losses in billions 2018 USD",
+      yAxisTitle: "Losses in billions USD",
       expectedSeries: expectedUSDSeries,
     },
   ])("should initialise the chart with correct options for cost basis of $costBasis", async ({ costBasis, yAxisTitle, expectedSeries }) => {
@@ -199,7 +199,7 @@ describe("costs chart", () => {
     {
       from: CostBasis.PercentGDP,
       to: CostBasis.USD,
-      yAxisTitle: "Losses in billions 2018 USD",
+      yAxisTitle: "Losses in billions USD",
       expectedSeries: expectedUSDSeries,
     },
   ])("should update the chart when changing cost basis from $from to $to", async ({ from, to, yAxisTitle, expectedSeries }) => {

--- a/tests/unit/components/CostBasisToggler.spec.ts
+++ b/tests/unit/components/CostBasisToggler.spec.ts
@@ -91,7 +91,7 @@ describe("cost basis toggler", () => {
 
     const tooltipTrigger = component.find("img");
     expect(tooltipTrigger.attributes("src")).toBe("/icons/info.png");
-    await expectTooltipContents(tooltipTrigger, ["2018 GDP of $19,863.0 billion"]);
+    await expectTooltipContents(tooltipTrigger, ["pre-pandemic GDP of $19,863.0 billion"]);
   });
 
   it("should show the correct tooltip content when the scenarios each have a different national GDP", async () => {
@@ -105,7 +105,7 @@ describe("cost basis toggler", () => {
     const tooltipTrigger = component.find("img");
     expect(tooltipTrigger.attributes("src")).toBe("/icons/info.png");
     await expectTooltipContents(tooltipTrigger, [
-      "2018 GDPs:",
+      "the following pre-pandemic GDPs",
       "United Kingdom (baseline): $19,863.0 billion",
       "United States: $123.5 billion",
     ]);

--- a/tests/unit/components/CostsChart.spec.ts
+++ b/tests/unit/components/CostsChart.spec.ts
@@ -249,7 +249,7 @@ describe("costs chart", () => {
           }),
           yAxis: expect.objectContaining({
             title: expect.objectContaining({
-              text: "Losses in billions 2018 USD",
+              text: "Losses in billions USD",
             }),
           }),
           series: expectedUSDSeries,
@@ -307,7 +307,7 @@ describe("costs chart", () => {
         expect.objectContaining({
           yAxis: expect.objectContaining({
             title: expect.objectContaining({
-              text: "Losses in billions 2018 USD",
+              text: "Losses in billions USD",
             }),
           }),
           series: expectedUSDSeries,

--- a/tests/unit/components/CostsTable.spec.ts
+++ b/tests/unit/components/CostsTable.spec.ts
@@ -67,7 +67,6 @@ describe("costs table for the current scenario", () => {
     let componentText = component.text();
 
     expect(componentText).toContain("$, millions");
-    expect(componentText).toContain("2018 USD");
 
     expect(componentText).toContain("Expand all");
     expect(componentText).not.toContain("Collapse all");
@@ -185,7 +184,6 @@ describe("costs table for all scenarios in a comparison", () => {
     let componentText = component.text();
 
     expect(componentText).toContain("$, millions");
-    expect(componentText).toContain("2018 USD");
 
     // Scenario labels
     expect(componentText).toContain("None");

--- a/tests/unit/components/utils/costCharts.spec.ts
+++ b/tests/unit/components/utils/costCharts.spec.ts
@@ -46,7 +46,7 @@ describe("single-scenario costs chart tooltip text for stacked column", () => {
   it("should return the correct text for the stack's tooltip, when cost basis is USD", () => {
     const tooltipText = costsChartSingleScenarioTooltip(tooltipPointInstance, CostBasis.USD, 4000);
     expect(tooltipText).toMatch(
-      /Life years losses.*\$2.0 billion.*2018 USD.*50.0% of pre-pandemic GDP.*#FF0000.*Working-age adults.*\$999 M.*#00FF00.*Children.*\$0 M/,
+      /Life years losses.*\$2.0 billion.*USD.*50.0% of pre-pandemic GDP.*#FF0000.*Working-age adults.*\$999 M.*#00FF00.*Children.*\$0 M/,
     );
     expect(tooltipText).not.toMatch(/Do not include in tooltips/i);
   });
@@ -99,7 +99,7 @@ describe("multi-scenario costs chart tooltip text for stacked column", () => {
       context.point.total = 1885507.7183;
       const tooltipText = costsChartMultiScenarioStackedTooltip(context, CostBasis.USD, vaccineParam);
       expect(tooltipText).toMatch(
-        /Global vaccine investment:.*High.*Total losses:.*\$1.9 trillion.*2018 USD.*74.0% of pre-pandemic GDP.*#FF0000.*GDP.*\$97.4 B.*#00FF00.*Education.*\$2.7 B.*#0000FF.*\$1.8 T/,
+        /Global vaccine investment:.*High.*Total losses:.*\$1.9 trillion.*USD.*74.0% of pre-pandemic GDP.*#FF0000.*GDP.*\$97.4 B.*#00FF00.*Education.*\$2.7 B.*#0000FF.*\$1.8 T/,
       );
     });
 
@@ -125,7 +125,7 @@ describe("multi-scenario costs chart tooltip text for stacked column", () => {
       context.point.total = 1885507.7183;
       const tooltipText = costsChartMultiScenarioStackedTooltip(context, CostBasis.USD, hospitalCapacityParam);
       expect(tooltipText).toMatch(
-        /Hospital surge capacity:.*12,345.*Total losses:.*\$1.9 trillion.*2018 USD.*74.0% of pre-pandemic GDP.*#FF0000.*GDP.*\$97.4 B.*#00FF00.*Education.*\$2.7 B.*#0000FF.*\$1.8 T/,
+        /Hospital surge capacity:.*12,345.*Total losses:.*\$1.9 trillion.*USD.*74.0% of pre-pandemic GDP.*#FF0000.*GDP.*\$97.4 B.*#00FF00.*Education.*\$2.7 B.*#0000FF.*\$1.8 T/,
       );
     });
 


### PR DESCRIPTION
In EPPI dashboard meeting we decided that '2018 USD' and the equivalent for the costs table are incorrect/misleading, and should just say USD, with the basis of the calculation explained in a tooltip, phrased just as it already is.

Iterating https://github.com/jameel-institute/daedalus-web-app/pull/149, see comment:

> Rob said that this way of expressing units was misleading - "in 2018 USD" sounds like it means the figures are in terms of dollars that have the value dollars did in 2018. Whereas what we really mean to communicate is that our data on how big the economy was at the start of the pandemic comes from 2018, and users may wish to account for the economy being differently sized now.
