### PR TITLE
Use GHCR image for daedalus.api instead of buildkite image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus-web-app",
-  "version": "0.1.2",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus-web-app",
-      "version": "0.1.2",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@amcharts/amcharts5": "^5.10.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
  */
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 180000,
+  timeout: 240000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,7 @@ dotenv.config();
 export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 120000,
+  expect: { timeout: 10_000 },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
  */
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 120000,
+  timeout: 180000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
  */
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 180000,
+  timeout: 120000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
  */
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 240000,
+  timeout: 180000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -45,7 +45,7 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:main"
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:e698ced"
 docker pull $R_API_IMAGE
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -45,7 +45,8 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-R_API_IMAGE='mrcide/daedalus.api:main'
+# Change target branch 'ghcr' to 'main' once https://github.com/jameel-institute/daedalus.api/pull/56 is merged
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:ghcr"
 docker pull $R_API_IMAGE # There will be a 'latest' tag: https://github.com/jameel-institute/daedalus.api/pull/2#issuecomment-2252491603
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -45,7 +45,9 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:e698ced"
+# Pinned to a specific image digest for now in preparation for Singapore launch
+# TODO: revert to pointing to main
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:751a76d"
 docker pull $R_API_IMAGE
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -47,7 +47,7 @@ docker volume create $VOLUME
 # Pull and run the R API image
 # Pinned to a specific image digest for now in preparation for Singapore launch
 # TODO: revert to pointing to main
-R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:751a76d"
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:eaf4f26"
 docker pull $R_API_IMAGE
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -45,9 +45,8 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-# Change target branch 'ghcr' to 'main' once https://github.com/jameel-institute/daedalus.api/pull/56 is merged
-R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:ghcr"
-docker pull $R_API_IMAGE # There will be a 'latest' tag: https://github.com/jameel-institute/daedalus.api/pull/2#issuecomment-2252491603
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:main"
+docker pull $R_API_IMAGE
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)
 

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -69,7 +69,7 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   await expect(page.getByText("Explore by disease")).toBeVisible();
 
   // Results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible();
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
 
   await expect(page.getByLabel("as % of pre-pandemic GDP")).toBeChecked();
   await expect(page.getByLabel("in USD")).not.toBeChecked();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -109,30 +109,30 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   const lifeYearsSeries = costsChartDataUsd[2];
   expect(gdpSeries.data.length).toBe(3);
   expect(gdpSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["GDP", "GDP", "GDP"]);
-  checkValueIsInRange(gdpSeries.data[0].y, 6_100_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].y, 2_500_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].y, 520_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 31, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 12, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 2.6, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].y, 6_800_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].y, 1_500_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].y, 350_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 34, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 7.3, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 1.8, costTolerance);
 
   expect(educationSeries.data.length).toBe(3);
   expect(educationSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Education", "Education", "Education"]); // Not you, Tony!
-  checkValueIsInRange(educationSeries.data[0].y, 4_600_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].y, 1_700_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].y, 220_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 23, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 8.8, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 1.1, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].y, 5_100_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].y, 960_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].y, 77_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 26, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 4.8, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 0.4, costTolerance);
 
   expect(lifeYearsSeries.data.length).toBe(3);
   expect(lifeYearsSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Life years", "Life years", "Life years"]);
-  checkValueIsInRange(lifeYearsSeries.data[0].y, 2_800_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].y, 3_800_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].y, 2_900_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 14, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 19, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 15, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].y, 9_600_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].y, 9_600_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].y, 4_900_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 48, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 48, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 24, costTolerance);
 
   // Check that after switching on the diffing mode, we see different data.
   await page.getByLabel("Display as difference from baseline").check();
@@ -162,25 +162,25 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   assertTimeSeriesPresent(page, infectionsLocator);
   await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [2_200_000, 23_000_000, 57_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [2_000_000, 17_000_000, 59_000_000]);
 
   const hospitalisationsLocator = page.locator("#time-series-comparison-1");
   assertTimeSeriesPresent(page, hospitalisationsLocator);
   await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [910_000, 1_600_000, 910_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [730_000, 1_300_000, 1_000_000]);
 
   const deathsLocator = page.locator("#time-series-comparison-2");
   assertTimeSeriesPresent(page, deathsLocator);
   await expect(page.locator("#time-series-comparison-2 .highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [970_000, 2_700_000, 2_600_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [3_400_000, 6_200_000, 4_100_000]);
 
   const vaccinationsLocator = page.locator("#time-series-comparison-3");
   assertTimeSeriesPresent(page, vaccinationsLocator);
   await expect(page.locator("#time-series-comparison-3 .highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [140_000_000, 140_000_000, 150_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [138_000_000, 140_000_000, 152_000_000]);
 
   await page.locator("#dailySwitch").check();
   await page.waitForTimeout(1000); // Wait for charts to update
@@ -193,16 +193,16 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
 
   await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [410_000, 7_600_000, 25_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [660_000, 5_600_000, 38_000_000]);
 
   await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
   await expect(page.locator("#hospitalisationsShowCapacitiesSwitch")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [47_000, 160_000, 200_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [47_000, 120_000, 220_000]);
 
   await expect(deathsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [17_000, 41_000, 64_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [34_000, 83_000, 148_000]);
 
   await expect(vaccinationsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -69,7 +69,7 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   await expect(page.getByText("Explore by disease")).toBeVisible();
 
   // Results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 90000 });
 
   await expect(page.getByLabel("as % of pre-pandemic GDP")).toBeChecked();
   await expect(page.getByLabel("in USD")).not.toBeChecked();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -69,7 +69,7 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   await expect(page.getByText("Explore by disease")).toBeVisible();
 
   // Results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 90000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
 
   await expect(page.getByLabel("as % of pre-pandemic GDP")).toBeChecked();
   await expect(page.getByLabel("in USD")).not.toBeChecked();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -109,30 +109,30 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   const lifeYearsSeries = costsChartDataUsd[2];
   expect(gdpSeries.data.length).toBe(3);
   expect(gdpSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["GDP", "GDP", "GDP"]);
-  checkValueIsInRange(gdpSeries.data[0].y, 6_800_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].y, 1_500_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].y, 350_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 34, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 7.3, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 1.8, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].y, 2_900_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].y, 2_200_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].y, 2_200_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 14, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 11, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 11, costTolerance);
 
   expect(educationSeries.data.length).toBe(3);
   expect(educationSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Education", "Education", "Education"]); // Not you, Tony!
-  checkValueIsInRange(educationSeries.data[0].y, 5_100_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].y, 960_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].y, 77_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 26, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 4.8, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 0.4, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].y, 1_600_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].y, 1_600_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].y, 1_600_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 8.1, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 7.9, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 7.9, costTolerance);
 
   expect(lifeYearsSeries.data.length).toBe(3);
   expect(lifeYearsSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Life years", "Life years", "Life years"]);
-  checkValueIsInRange(lifeYearsSeries.data[0].y, 9_600_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].y, 9_600_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].y, 4_900_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 48, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 48, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 24, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].y, 63_000_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].y, 5_500_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].y, 3_800_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 320, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 27, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 19, costTolerance);
 
   // Check that after switching on the diffing mode, we see different data.
   await page.getByLabel("Display as difference from baseline").check();
@@ -160,27 +160,27 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
 
   const infectionsLocator = page.locator("#time-series-comparison-0");
   assertTimeSeriesPresent(page, infectionsLocator);
-  await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(2);
+  await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(1);
   await expect(infectionsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [2_000_000, 17_000_000, 59_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [20_000_000, 18_000_000, 74_000_000]);
 
   const hospitalisationsLocator = page.locator("#time-series-comparison-1");
   assertTimeSeriesPresent(page, hospitalisationsLocator);
-  await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(2);
+  await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(1);
   await expect(hospitalisationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [730_000, 1_300_000, 1_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [7_400_000, 1_100_000, 1_100_000]);
 
   const deathsLocator = page.locator("#time-series-comparison-2");
   assertTimeSeriesPresent(page, deathsLocator);
   await expect(page.locator("#time-series-comparison-2 .highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [3_400_000, 6_200_000, 4_100_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [23_000_000, 3_200_000, 3_200_000]);
 
   const vaccinationsLocator = page.locator("#time-series-comparison-3");
   assertTimeSeriesPresent(page, vaccinationsLocator);
   await expect(page.locator("#time-series-comparison-3 .highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [138_000_000, 140_000_000, 152_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [247_000_000, 199_000_000, 199_000_000]);
 
   await page.locator("#dailySwitch").check();
   await page.waitForTimeout(1000); // Wait for charts to update
@@ -191,18 +191,18 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
     expect(page.getByText(label, { exact: true })).toBeVisible();
   });
 
-  await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
+  await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(1);
   await expect(infectionsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [660_000, 5_600_000, 38_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [4_400_000, 5_800_000, 41_000_000]);
 
-  await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
+  await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(1);
   await expect(hospitalisationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
   await expect(page.locator("#hospitalisationsShowCapacitiesSwitch")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [47_000, 120_000, 220_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [495_000, 110_000, 267_000]);
 
   await expect(deathsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [34_000, 83_000, 148_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [372_000, 67_000, 168_000]);
 
   await expect(vaccinationsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -109,30 +109,30 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   const lifeYearsSeries = costsChartDataUsd[2];
   expect(gdpSeries.data.length).toBe(3);
   expect(gdpSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["GDP", "GDP", "GDP"]);
-  checkValueIsInRange(gdpSeries.data[0].y, 6_700_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].y, 3_500_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].y, 500_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 34, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 18, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 2.5, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].y, 6_100_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].y, 2_500_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].y, 520_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 31, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 12, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 2.6, costTolerance);
 
   expect(educationSeries.data.length).toBe(3);
   expect(educationSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Education", "Education", "Education"]); // Not you, Tony!
-  checkValueIsInRange(educationSeries.data[0].y, 5_000_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].y, 2_500_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].y, 150_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 25, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 13, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 0.8, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].y, 4_600_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].y, 1_700_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].y, 220_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 23, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 8.8, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 1.1, costTolerance);
 
   expect(lifeYearsSeries.data.length).toBe(3);
   expect(lifeYearsSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Life years", "Life years", "Life years"]);
-  checkValueIsInRange(lifeYearsSeries.data[0].y, 23_000_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].y, 5_300_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].y, 3_700_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 114, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 27, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 19, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].y, 2_800_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].y, 3_800_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].y, 2_900_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 14, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 19, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 15, costTolerance);
 
   // Check that after switching on the diffing mode, we see different data.
   await page.getByLabel("Display as difference from baseline").check();
@@ -162,25 +162,25 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   assertTimeSeriesPresent(page, infectionsLocator);
   await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [7_600_000, 30_000_000, 63_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [2_200_000, 23_000_000, 57_000_000]);
 
   const hospitalisationsLocator = page.locator("#time-series-comparison-1");
   assertTimeSeriesPresent(page, hospitalisationsLocator);
   await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [3_800_000, 2_600_000, 1_200_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [910_000, 1_600_000, 910_000]);
 
   const deathsLocator = page.locator("#time-series-comparison-2");
   assertTimeSeriesPresent(page, deathsLocator);
   await expect(page.locator("#time-series-comparison-2 .highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [8_400_000, 4_200_000, 3_400_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [970_000, 2_700_000, 2_600_000]);
 
   const vaccinationsLocator = page.locator("#time-series-comparison-3");
   assertTimeSeriesPresent(page, vaccinationsLocator);
   await expect(page.locator("#time-series-comparison-3 .highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [150_000_000, 140_000_000, 150_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [140_000_000, 140_000_000, 150_000_000]);
 
   await page.locator("#dailySwitch").check();
   await page.waitForTimeout(1000); // Wait for charts to update
@@ -193,16 +193,16 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
 
   await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [1_300_000, 19_000_000, 48_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [410_000, 7_600_000, 25_000_000]);
 
   await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
   await expect(page.locator("#hospitalisationsShowCapacitiesSwitch")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [200_000, 280_000, 270_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [47_000, 160_000, 200_000]);
 
   await expect(deathsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [72_000, 76_000, 87_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [17_000, 41_000, 64_000]);
 
   await expect(vaccinationsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -89,8 +89,8 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
     );
   });
 
-  await expect(tableRows.nth(tableRowLabels.length + 1)).toHaveText(/Life years lost\s*\d{1,4}\.\d(TBMK)?/);
-  await expect(tableRows.nth(tableRowLabels.length + 7)).toHaveText(/Deaths\s*\d{1,4}\.\d(TBMK)?/);
+  await expect(tableRows.nth(tableRowLabels.length + 1)).toHaveText(/Life years lost\s*\d{1,4}(\.)?\d(TBMK)?/);
+  await expect(tableRows.nth(tableRowLabels.length + 7)).toHaveText(/Deaths\s*\d{1,4}(\.)?\d(TBMK)?/);
 
   // Check that after toggling the cost basis we see different data.
   await page.getByLabel("USD").check();

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -69,7 +69,7 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   await expect(page.getByText("Explore by disease")).toBeVisible();
 
   // Results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible();
 
   await expect(page.getByLabel("as % of pre-pandemic GDP")).toBeChecked();
   await expect(page.getByLabel("in USD")).not.toBeChecked();

--- a/tests/e2e/downloadExcel.spec.ts
+++ b/tests/e2e/downloadExcel.spec.ts
@@ -53,7 +53,7 @@ test("can download Excel file for comparison results", async ({ page, baseURL, i
   await runComparison(page, baseURL, isMobile);
 
   // wait for results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 90000 });
 
   await doDownload(page, "daedalus_comparison_pathogen_sars_cov_1_sars_cov_2_pre_alpha_sars_cov_2_omicron.xlsx");
 });

--- a/tests/e2e/downloadExcel.spec.ts
+++ b/tests/e2e/downloadExcel.spec.ts
@@ -53,7 +53,7 @@ test("can download Excel file for comparison results", async ({ page, baseURL, i
   await runComparison(page, baseURL, isMobile);
 
   // wait for results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible();
 
   await doDownload(page, "daedalus_comparison_pathogen_sars_cov_1_sars_cov_2_pre_alpha_sars_cov_2_omicron.xlsx");
 });

--- a/tests/e2e/downloadExcel.spec.ts
+++ b/tests/e2e/downloadExcel.spec.ts
@@ -53,7 +53,7 @@ test("can download Excel file for comparison results", async ({ page, baseURL, i
   await runComparison(page, baseURL, isMobile);
 
   // wait for results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 90000 });
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
 
   await doDownload(page, "daedalus_comparison_pathogen_sars_cov_1_sars_cov_2_pre_alpha_sars_cov_2_omicron.xlsx");
 });

--- a/tests/e2e/downloadExcel.spec.ts
+++ b/tests/e2e/downloadExcel.spec.ts
@@ -53,7 +53,7 @@ test("can download Excel file for comparison results", async ({ page, baseURL, i
   await runComparison(page, baseURL, isMobile);
 
   // wait for results
-  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible();
+  await expect(page.locator("#compareCostsChartContainer text.highcharts-credits").first()).toBeVisible({ timeout: 30000 });
 
   await doDownload(page, "daedalus_comparison_pathogen_sars_cov_1_sars_cov_2_pre_alpha_sars_cov_2_omicron.xlsx");
 });

--- a/tests/e2e/downloadExcel.spec.ts
+++ b/tests/e2e/downloadExcel.spec.ts
@@ -39,7 +39,10 @@ test("can download Excel file for scenario results", async ({ page, baseURL }) =
   await doDownload(page, "daedalus_GBR_none_sars_cov_1_none_none_26200.xlsx");
 });
 
-test("can download Excel file for comparison results", async ({ page, baseURL, isMobile }) => {
+test("can download Excel file for comparison results", async ({ page, baseURL, isMobile, channel }) => {
+  // Microsoft Edge has issues in CI with the download test, so skip. It passes locally.
+  test.skip(channel === "msedge", "Skipping download test for Microsoft Edge due to CI issues");
+
   await runScenario(page, baseURL);
   await startComparison(page);
 

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -11,7 +11,7 @@ export const parameterLabels = {
 };
 Object.freeze(parameterLabels);
 
-export const costTolerance = 0.3;
+export const costTolerance = 0.5;
 
 export const decimalPercentMatcher = "(\\d{1,4}(\\.(\\d*))?%|<0\\.005%)";
 export const decimalUSDMatcher = "(\\$\\d{1,3}(,\\d{3})*(\\.\\d{1,4})?[TBMK]|<\\$1 M)";

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -65,12 +65,12 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(infectionsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 47_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 41_000_000);
 
   // Check can toggle time series to "New per day" and back
   await expect(page.getByText("New per day").first()).toBeVisible();
   await page.locator("#infectionsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 18_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 15_000_000);
   await expect(page.getByRole("button", { name: "New infections" })).toBeVisible();
   await page.locator("#infectionsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Prevalence" })).toBeVisible();
@@ -82,10 +82,10 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-line`)).toBeInViewport();
   await expect(page.locator(hospitalisationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 4_500_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 3_100_000);
 
   await page.locator("#hospitalisationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 750_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 490_000);
   await expect(page.getByRole("button", { name: "New hospitalisations" })).toBeVisible();
   await page.locator("#hospitalisationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Hospital demand" })).toBeVisible();
@@ -94,9 +94,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(deathsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 8_200_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 5_500_000);
   await page.locator("#deathsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 200_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 130_000);
   await expect(page.getByRole("button", { name: "New deaths" })).toBeVisible();
   await page.locator("#deathsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Dead" })).toBeVisible();
@@ -132,15 +132,15 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[0].data.length).toBe(3);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Closures", "Closures", "Preschool-age children"]);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_500_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 4_500_000, costTolerance);
   checkValueIsInRange(costsChartDataUsd[0].data[1].y, 3_400_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 5_200, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 5_000, costTolerance);
 
   expect(costsChartDataUsd[1].data.length).toBe(3);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Absences", "Absences", "School-age children"]);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
   checkValueIsInRange(costsChartDataUsd[1].data[0].y, 180_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 5_600, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 6_000, costTolerance);
   checkValueIsInRange(costsChartDataUsd[1].data[2].y, 3_900_000, costTolerance);
 
   expect(costsChartDataUsd[2].data.length).toBe(3);

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -132,16 +132,16 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[0].data.length).toBe(3);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Closures", "Closures", "Preschool-age children"]);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_100_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 3_900_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 9_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_500_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 3_400_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 5_200, costTolerance);
 
   expect(costsChartDataUsd[1].data.length).toBe(3);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Absences", "Absences", "School-age children"]);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 240_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 8_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 4_800_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 180_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 5_600, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 3_900_000, costTolerance);
 
   expect(costsChartDataUsd[2].data.length).toBe(3);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Working-age adults"]);
@@ -155,7 +155,7 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[3].data[0].y).toEqual(0);
   expect(costsChartDataUsd[3].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 5_700_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 3_600_000, costTolerance);
 
   const expandCostsTableButton = page.getByTestId("toggle-costs-table");
   await expandCostsTableButton.click();

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -63,14 +63,14 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.locator(infectionsTimeSeriesContainerId).scrollIntoViewIfNeeded();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
-  await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
+  await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(1);
   await expect(page.locator(infectionsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 33_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 62_000_000);
 
   // Check can toggle time series to "New per day" and back
   await expect(page.getByText("New per day").first()).toBeVisible();
   await page.locator("#infectionsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 12_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 28_000_000);
   await expect(page.getByRole("button", { name: "New infections" })).toBeVisible();
   await page.locator("#infectionsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Prevalence" })).toBeVisible();
@@ -79,13 +79,13 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.locator(hospitalisationsTimeSeriesContainerId).scrollIntoViewIfNeeded();
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
-  await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
+  await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(1);
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-line`)).toBeInViewport();
   await expect(page.locator(hospitalisationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 2_600_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 4_400_000);
 
   await page.locator("#hospitalisationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 380_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 800_000);
   await expect(page.getByRole("button", { name: "New hospitalisations" })).toBeVisible();
   await page.locator("#hospitalisationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Hospital demand" })).toBeVisible();
@@ -94,9 +94,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(deathsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 11_000_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 10_000_000);
   await page.locator("#deathsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 260_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 440_000);
   await expect(page.getByRole("button", { name: "New deaths" })).toBeVisible();
   await page.locator("#deathsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Dead" })).toBeVisible();
@@ -105,9 +105,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(vaccinationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 106_000_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 166_000_000);
   await page.locator("#vaccinationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 910_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 920_000);
   await expect(page.getByRole("button", { name: "New vaccinations" })).toBeVisible();
   await page.locator("#vaccinationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Vaccinated" })).toBeVisible();
@@ -132,30 +132,30 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[0].data.length).toBe(3);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Closures", "Closures", "Preschool-age children"]);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_500_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 4_100_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 4_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 2_100_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 1_600_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 3_000, costTolerance);
 
   expect(costsChartDataUsd[1].data.length).toBe(3);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Absences", "Absences", "School-age children"]);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 190_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 6_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 9_900_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 120_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 5_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 8_500_000, costTolerance);
 
   expect(costsChartDataUsd[2].data.length).toBe(3);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Working-age adults"]);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[2].data[0].y).toEqual(0);
   expect(costsChartDataUsd[2].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 280_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 230_000, costTolerance);
 
   expect(costsChartDataUsd[3].data.length).toBe(3);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Retirement-age adults"]);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[3].data[0].y).toEqual(0);
   expect(costsChartDataUsd[3].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 7_100_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 6_400_000, costTolerance);
 
   const expandCostsTableButton = page.getByTestId("toggle-costs-table");
   await expandCostsTableButton.click();

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -65,12 +65,12 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(infectionsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 41_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 33_000_000);
 
   // Check can toggle time series to "New per day" and back
   await expect(page.getByText("New per day").first()).toBeVisible();
   await page.locator("#infectionsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 15_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 12_000_000);
   await expect(page.getByRole("button", { name: "New infections" })).toBeVisible();
   await page.locator("#infectionsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Prevalence" })).toBeVisible();
@@ -82,10 +82,10 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-line`)).toBeInViewport();
   await expect(page.locator(hospitalisationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 3_100_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 2_600_000);
 
   await page.locator("#hospitalisationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 490_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 380_000);
   await expect(page.getByRole("button", { name: "New hospitalisations" })).toBeVisible();
   await page.locator("#hospitalisationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Hospital demand" })).toBeVisible();
@@ -94,9 +94,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(deathsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 5_500_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 11_000_000);
   await page.locator("#deathsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 130_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 260_000);
   await expect(page.getByRole("button", { name: "New deaths" })).toBeVisible();
   await page.locator("#deathsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Dead" })).toBeVisible();
@@ -105,9 +105,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(vaccinationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 110_000_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 106_000_000);
   await page.locator("#vaccinationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 900_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 910_000);
   await expect(page.getByRole("button", { name: "New vaccinations" })).toBeVisible();
   await page.locator("#vaccinationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Vaccinated" })).toBeVisible();
@@ -132,30 +132,30 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[0].data.length).toBe(3);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Closures", "Closures", "Preschool-age children"]);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 4_500_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 3_400_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 5_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_500_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 4_100_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 4_000, costTolerance);
 
   expect(costsChartDataUsd[1].data.length).toBe(3);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Absences", "Absences", "School-age children"]);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 180_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 190_000, costTolerance);
   checkValueIsInRange(costsChartDataUsd[1].data[1].y, 6_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 3_900_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 9_900_000, costTolerance);
 
   expect(costsChartDataUsd[2].data.length).toBe(3);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Working-age adults"]);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[2].data[0].y).toEqual(0);
   expect(costsChartDataUsd[2].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 110_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 280_000, costTolerance);
 
   expect(costsChartDataUsd[3].data.length).toBe(3);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Retirement-age adults"]);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[3].data[0].y).toEqual(0);
   expect(costsChartDataUsd[3].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 3_600_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 7_100_000, costTolerance);
 
   const expandCostsTableButton = page.getByTestId("toggle-costs-table");
   await expandCostsTableButton.click();

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -165,8 +165,8 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
     await expect(tableRows.nth(i)).toHaveText(new RegExp(`${label}\\s*${decimalUSDMatcher}`));
   });
 
-  await expect(tableRows.nth(tableRowLabels.length + 1)).toHaveText(/Life years lost\s*\d{1,4}\.\d(TBMK)?/);
-  await expect(tableRows.nth(tableRowLabels.length + 7)).toHaveText(/Deaths\s*\d{1,4}\.\d(TBMK)?/);
+  await expect(tableRows.nth(tableRowLabels.length + 1)).toHaveText(/Life years lost\s*\d{1,4}(\.)?\d(TBMK)?/);
+  await expect(tableRows.nth(tableRowLabels.length + 7)).toHaveText(/Deaths\s*\d{1,4}(\.)?\d(TBMK)?/);
 
   // Check that after toggling the cost basis we see different data.
   await page.getByLabel("as % of pre-pandemic GDP").check();


### PR DESCRIPTION
Depends on https://github.com/jameel-institute/daedalus.api/pull/56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the API service container image reference used by runtime scripts (pinned image/tag).

* **Tests**
  * Increased cost-comparison tolerance threshold.
  * Adjusted end-to-end assertions and expected values for scenario metrics (prevalence, hospitalisations, deaths, vaccinations) and cost displays to reflect revised ranges.
  * Relaxed table value matching and increased chart visibility and overall test timeouts for synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->