### PR TITLE
Reset timers when navigating on the client side

### DIFF
--- a/pages/comparison.vue
+++ b/pages/comparison.vue
@@ -104,6 +104,7 @@ const query = useRoute().query;
 
 const jobSlow = ref(false);
 const secondsSinceFirstStatusPoll = ref("0");
+const timeOfFirstStatusPoll = ref(new Date().getTime());
 
 const showSpinner = computed(() => {
   return !everyScenarioIsDone.value
@@ -127,19 +128,10 @@ watch(() => appStore.metadata, async (newMetadata) => {
   }
 }, { immediate: true });
 
-// Use useAsyncData to store the time once, during server-side rendering: avoids client render re-writing value.
-const { data: timeOfFirstStatusPoll } = await useAsyncData<number>("timeOfFirstStatusPoll", async () => {
-  return new Promise<number>((resolve) => {
-    resolve(new Date().getTime());
-  });
-});
-
 const stopWatchingComparison = watch(everyScenarioIsDone, () => {
   if (!statusInterval && appStore.everyScenarioHasARunId) {
     statusInterval = setInterval(() => {
-      if (timeOfFirstStatusPoll.value) {
-        secondsSinceFirstStatusPoll.value = ((new Date().getTime() - timeOfFirstStatusPoll.value) / 1000).toFixed(0);
-      };
+      secondsSinceFirstStatusPoll.value = ((new Date().getTime() - timeOfFirstStatusPoll.value) / 1000).toFixed(0);
       appStore.refreshComparisonStatuses(nuxtApp);
     }, 200);
     setTimeout(() => {

--- a/pages/scenarios/[runId].vue
+++ b/pages/scenarios/[runId].vue
@@ -83,6 +83,7 @@ const appStore = useAppStore();
 
 let statusInterval: NodeJS.Timeout;
 const jobSlow = ref(false);
+const timeOfFirstStatusPoll = ref(new Date().getTime());
 const secondsSinceFirstStatusPoll = ref("0");
 const scenarioStatusResponseError = computed(() => appStore.currentScenario.status.fetchError);
 const scenarioResultResponseError = computed(() => appStore.currentScenario.result.fetchError);
@@ -110,13 +111,6 @@ appStore.downloadError = undefined;
 // Fetch scenario from db so we can know its parameters now rather than wait for them in the result data
 appStore.currentScenario.runId = runId;
 await appStore.loadScenarioDetails(appStore.currentScenario);
-
-// Use useAsyncData to store the time once, during server-side rendering: avoids client render re-writing value.
-const { data: timeOfFirstStatusPoll } = await useAsyncData<number>("timeOfFirstStatusPoll", async () => {
-  return new Promise<number>((resolve) => {
-    resolve(new Date().getTime());
-  });
-});
 
 const codeSnippet = ref<{ modalVisible: boolean } | null>(null);
 
@@ -147,9 +141,7 @@ watch(() => appStore.currentScenario.status.data?.done, (done) => {
 
 const pollForStatusEveryNSeconds = (seconds: number) => {
   statusInterval = setInterval(() => {
-    if (timeOfFirstStatusPoll.value) {
-      secondsSinceFirstStatusPoll.value = ((new Date().getTime() - timeOfFirstStatusPoll.value) / 1000).toFixed(0);
-    };
+    secondsSinceFirstStatusPoll.value = ((new Date().getTime() - timeOfFirstStatusPoll.value) / 1000).toFixed(0);
     appStore.refreshScenarioStatus(appStore.currentScenario);
   }, seconds * 1000);
 };


### PR DESCRIPTION
Contrary to the code comment being removed, the most common type of navigation is actually client-side navigation (e.g. when you change parameters from a given scenario to another). In such cases we need to reset the record of the time of the first status poll, so that alert messages telling the user 'you've been waiting X seconds' actually reset back to 0 after a navigation. (This also applies to navigating from a scenario to a comparison, and then via a baseline to a new comparison, when all those navigations are client-side i.e. via clicking UI buttons instead of typing in the address bar - and it's easier to see the bug in this case because comparisons tend to take longer than single scenarios, and so you're more likely to see the 'it's taking a while' alert when doing a comparison.)

The bug was that this number was not being reset for client-side navigation, so each time you saw an alert message about a long wait period, it was telling you the seconds since you requested some earlier thing, not the current thing you are waiting for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of job timing detection on comparison and scenario pages by refining how initial status timestamps are captured and calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->