### PR TITLE
De-dupe scenario select options

### DIFF
--- a/composables/useScenarioOptions.ts
+++ b/composables/useScenarioOptions.ts
@@ -50,7 +50,8 @@ export default (parameterAxis: MaybeRefOrGetter<Parameter | undefined>) => {
       return [];
     }
     if (axis.value?.parameterType === TypeOfParameter.Numeric) {
-      return predefinedNumericOptions.value?.filter(o => o.id !== baselineOption.value?.id) || [];
+      const opts = predefinedNumericOptions.value?.filter(o => o.id !== baselineOption.value?.id) || [];
+      return opts.filter((opt, index, self) => index === self.findIndex(o => o.id === opt.id)); // dedupe by id
     }
     return axis.value?.options?.filter(({ id }) => {
       return baselineOption.value && id !== baselineOption.value?.id;

--- a/composables/useScenarioOptions.ts
+++ b/composables/useScenarioOptions.ts
@@ -1,6 +1,7 @@
 import { type Parameter, type ParameterOption, TypeOfParameter } from "~/types/parameterTypes";
 import { getRangeForDependentParam, paramOptsToSelectOpts } from "~/components/utils/parameters";
 import { commaSeparatedNumber } from "~/components/utils/formatters";
+import type { DisplayInfo } from "~/types/apiResponseTypes";
 
 export default (parameterAxis: MaybeRefOrGetter<Parameter | undefined>) => {
   const appStore = useAppStore();
@@ -50,8 +51,14 @@ export default (parameterAxis: MaybeRefOrGetter<Parameter | undefined>) => {
       return [];
     }
     if (axis.value?.parameterType === TypeOfParameter.Numeric) {
-      const opts = predefinedNumericOptions.value?.filter(o => o.id !== baselineOption.value?.id) || [];
-      return opts.filter((opt, index, self) => index === self.findIndex(o => o.id === opt.id)); // dedupe by id
+      const filteredOpts: DisplayInfo[] = [];
+      predefinedNumericOptions.value?.forEach((o) => {
+        // Exclude the baseline, and de-dupe by id.
+        if (o.id !== baselineOption.value?.id && !filteredOpts.find(x => x.id === o.id)) {
+          filteredOpts.push(o);
+        }
+      });
+      return filteredOpts;
     }
     return axis.value?.options?.filter(({ id }) => {
       return baselineOption.value && id !== baselineOption.value?.id;

--- a/tests/unit/composables/useScenarioOptions.spec.ts
+++ b/tests/unit/composables/useScenarioOptions.spec.ts
@@ -1,10 +1,12 @@
 import type { Parameter } from "~/types/parameterTypes";
+import { setActivePinia } from "pinia";
 import { mockMetadataResponseData } from "../mocks/mockResponseData";
-import { emptyScenario } from "../mocks/mockPinia";
+import { emptyScenario, mockPinia, updatableNumericParameter } from "../mocks/mockPinia";
 
-beforeAll(() => {
-  const store = useAppStore();
-  store.currentScenario = { ...structuredClone(emptyScenario), parameters: { vaccine: "none", hospital_capacity: "12345" } };
+beforeEach(() => {
+  setActivePinia(mockPinia({
+    currentScenario: { ...structuredClone(emptyScenario), parameters: { vaccine: "none", hospital_capacity: "12345" } },
+  }));
 });
 
 describe("useScenarioOptions composable", () => {
@@ -45,5 +47,36 @@ describe("useScenarioOptions composable", () => {
     expect(baselineOption.value).toEqual({ id: "12345", label: "12,345", description: "" });
     expect(predefinedOptions.value).toHaveLength(0);
     expect(predefinedSelectOptions.value).toHaveLength(0);
+  });
+
+  it("deduplicates predefined numeric options with repeated ids", () => {
+    const store = useAppStore();
+    store.currentScenario = {
+      ...structuredClone(emptyScenario),
+      parameters: {
+        short_list: "no",
+        population: "9999",
+      },
+    };
+
+    const parameterAxis = ref<Parameter>();
+    const { predefinedOptions, predefinedSelectOptions } = useScenarioOptions(parameterAxis);
+
+    parameterAxis.value = {
+      ...structuredClone(updatableNumericParameter),
+      updateNumericFrom: {
+        parameterId: "short_list",
+        values: {
+          no: {
+            min: 1000,
+            default: 1000,
+            max: 4000,
+          },
+        },
+      },
+    };
+
+    expect(predefinedOptions.value.map(option => option.id)).toEqual(["1000", "4000"]);
+    expect(predefinedSelectOptions.value.map(option => option.value)).toEqual(["1000", "4000"]);
   });
 });


### PR DESCRIPTION
'Scenario-selecting' refers to choosing the scenarios you want to include in a comparison. The multi-select input that initiates a comparison pre-loads some suggestions/defaults. For the case of comparing scenarios by hospital capacity, it pre-loads 3 suggested values: the minimum capacity, default capacity, and maximum capacity that are configured for the current country. But that implementation assumes those 3 values are unique, which is not always the case. For very small countries, the minimum and/or maximum may be the same as the default (see e.g. [Costa Rica](https://github.com/jameel-institute/daedalus-web-app/blob/176a31e2f99b3a915cda8c3166fd1718a009983c/mocks/responses/metadata.json#L482)). In such cases we should de-duplicate the suggested/pre-loaded options, so e.g. when you are in Costa Rica and set hospital capacity to 700, the options presented (when you attempt to compare by hospital capacity) should be 600 and 800, rather than 600, 600 and 800:

<img width="688" height="328" alt="Screenshot from 2026-05-26 11-10-26" src="https://github.com/user-attachments/assets/08103825-8c8f-4483-ae1c-d95278a6767b" />

And post the fix:

<img width="688" height="328" alt="image" src="https://github.com/user-attachments/assets/aa8c9970-6cd0-4f38-99a8-94663d8fe955" />

So this branch addresses the edge-case where some scenario select options are the same, by de-duplicating them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate entries in predefined numeric options and ensured the current baseline option is excluded so scenario option lists show unique, relevant values.

* **Tests**
  * Added unit coverage verifying deduplication of predefined numeric options and the baseline exclusion behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jameel-institute/daedalus-web-app/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->