### PR TITLE
Revert R API image to point to 'main' image post-Singapore launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daedalus-web-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "daedalus-web-app",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "dependencies": {
         "@amcharts/amcharts5": "^5.10.5",
@@ -10530,7 +10530,7 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
       "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -12291,7 +12291,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^2.0.0"
@@ -20364,7 +20364,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20546,7 +20546,7 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
       "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -22421,6 +22421,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -24425,7 +24426,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24446,7 +24447,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "decompress-response": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus-web-app",
   "type": "module",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "engines": {
     "node": "^20"

--- a/scripts/run-dependencies
+++ b/scripts/run-dependencies
@@ -45,9 +45,7 @@ docker network connect daedalus daedalus-web-app-db
 docker volume create $VOLUME
 
 # Pull and run the R API image
-# Pinned to a specific image digest for now in preparation for Singapore launch
-# TODO: revert to pointing to main
-R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:eaf4f26"
+R_API_IMAGE="ghcr.io/jameel-institute/daedalus.api:main"
 docker pull $R_API_IMAGE
 
 QUEUE_ID=daedalus-api-queue-$(uuidgen)

--- a/tests/e2e/compareScenarios.spec.ts
+++ b/tests/e2e/compareScenarios.spec.ts
@@ -109,30 +109,30 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
   const lifeYearsSeries = costsChartDataUsd[2];
   expect(gdpSeries.data.length).toBe(3);
   expect(gdpSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["GDP", "GDP", "GDP"]);
-  checkValueIsInRange(gdpSeries.data[0].y, 2_900_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].y, 2_200_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].y, 2_200_000, costTolerance);
-  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 14, costTolerance);
-  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 11, costTolerance);
-  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 11, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].y, 6_800_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].y, 1_500_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].y, 350_000, costTolerance);
+  checkValueIsInRange(gdpSeries.data[0].custom.costAsGdpPercent, 35, costTolerance);
+  checkValueIsInRange(gdpSeries.data[1].custom.costAsGdpPercent, 7, costTolerance);
+  checkValueIsInRange(gdpSeries.data[2].custom.costAsGdpPercent, 1.8, costTolerance);
 
   expect(educationSeries.data.length).toBe(3);
   expect(educationSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Education", "Education", "Education"]); // Not you, Tony!
-  checkValueIsInRange(educationSeries.data[0].y, 1_600_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].y, 1_600_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].y, 1_600_000, costTolerance);
-  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 8.1, costTolerance);
-  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 7.9, costTolerance);
-  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 7.9, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].y, 5_100_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].y, 960_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].y, 80_000, costTolerance);
+  checkValueIsInRange(educationSeries.data[0].custom.costAsGdpPercent, 26, costTolerance);
+  checkValueIsInRange(educationSeries.data[1].custom.costAsGdpPercent, 5, costTolerance);
+  checkValueIsInRange(educationSeries.data[2].custom.costAsGdpPercent, 0.4, costTolerance);
 
   expect(lifeYearsSeries.data.length).toBe(3);
   expect(lifeYearsSeries.data.map((dataPoint: any) => dataPoint.name)).toEqual(["Life years", "Life years", "Life years"]);
-  checkValueIsInRange(lifeYearsSeries.data[0].y, 63_000_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].y, 5_500_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].y, 3_800_000, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 320, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 27, costTolerance);
-  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 19, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].y, 9_600_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].y, 9_600_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].y, 4_900_000, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[0].custom.costAsGdpPercent, 48, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[1].custom.costAsGdpPercent, 48, costTolerance);
+  checkValueIsInRange(lifeYearsSeries.data[2].custom.costAsGdpPercent, 24, costTolerance);
 
   // Check that after switching on the diffing mode, we see different data.
   await page.getByLabel("Display as difference from baseline").check();
@@ -160,27 +160,27 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
 
   const infectionsLocator = page.locator("#time-series-comparison-0");
   assertTimeSeriesPresent(page, infectionsLocator);
-  await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(1);
+  await expect(page.locator("#time-series-comparison-0 .highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [20_000_000, 18_000_000, 74_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [2_000_000, 17_000_000, 60_000_000]);
 
   const hospitalisationsLocator = page.locator("#time-series-comparison-1");
   assertTimeSeriesPresent(page, hospitalisationsLocator);
-  await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(1);
+  await expect(page.locator("#time-series-comparison-1 .highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [7_400_000, 1_100_000, 1_100_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [700_000, 1_300_000, 1_000_000]);
 
   const deathsLocator = page.locator("#time-series-comparison-2");
   assertTimeSeriesPresent(page, deathsLocator);
   await expect(page.locator("#time-series-comparison-2 .highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [23_000_000, 3_200_000, 3_200_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [3_300_000, 6_200_000, 3_300_000]);
 
   const vaccinationsLocator = page.locator("#time-series-comparison-3");
   assertTimeSeriesPresent(page, vaccinationsLocator);
   await expect(page.locator("#time-series-comparison-3 .highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [247_000_000, 199_000_000, 199_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(vaccinationsLocator, [137_000_000, 140_000_000, 150_000_000]);
 
   await page.locator("#dailySwitch").check();
   await page.waitForTimeout(1000); // Wait for charts to update
@@ -191,18 +191,18 @@ test("Can compare multiple scenarios", async ({ baseURL, context, isMobile, page
     expect(page.getByText(label, { exact: true })).toBeVisible();
   });
 
-  await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(1);
+  await expect(infectionsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(infectionsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [4_400_000, 5_800_000, 41_000_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(infectionsLocator, [500_000, 5_400_000, 32_000_000]);
 
-  await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(1);
+  await expect(hospitalisationsLocator.locator(".highcharts-plot-band")).toHaveCount(2);
   await expect(hospitalisationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
   await expect(page.locator("#hospitalisationsShowCapacitiesSwitch")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [495_000, 110_000, 267_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(hospitalisationsLocator, [50_000, 120_000, 217_000]);
 
   await expect(deathsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(deathsLocator.locator(".highcharts-plot-line")).not.toBeVisible();
-  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [372_000, 67_000, 168_000]);
+  await checkMultiScenarioTimeSeriesDataPoints(deathsLocator, [34_000, 82_000, 147_000]);
 
   await expect(vaccinationsLocator.locator(".highcharts-plot-band")).toHaveCount(0);
   await expect(vaccinationsLocator.locator(".highcharts-plot-line")).not.toBeVisible();

--- a/tests/e2e/runScenario.spec.ts
+++ b/tests/e2e/runScenario.spec.ts
@@ -63,14 +63,14 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.locator(infectionsTimeSeriesContainerId).scrollIntoViewIfNeeded();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
-  await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(1);
+  await expect(page.locator(`${infectionsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(infectionsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 62_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 33_000_000);
 
   // Check can toggle time series to "New per day" and back
   await expect(page.getByText("New per day").first()).toBeVisible();
   await page.locator("#infectionsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 28_000_000);
+  await checkTimeSeriesDataPoints(page.locator(infectionsTimeSeriesContainerId), 12_000_000);
   await expect(page.getByRole("button", { name: "New infections" })).toBeVisible();
   await page.locator("#infectionsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Prevalence" })).toBeVisible();
@@ -79,13 +79,13 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await page.locator(hospitalisationsTimeSeriesContainerId).scrollIntoViewIfNeeded();
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
-  await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(1);
+  await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-band`)).toHaveCount(2);
   await expect(page.locator(`${hospitalisationsTimeSeriesContainerId} .highcharts-plot-line`)).toBeInViewport();
   await expect(page.locator(hospitalisationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 4_400_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 2_600_000);
 
   await page.locator("#hospitalisationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 800_000);
+  await checkTimeSeriesDataPoints(page.locator(hospitalisationsTimeSeriesContainerId), 400_000);
   await expect(page.getByRole("button", { name: "New hospitalisations" })).toBeVisible();
   await page.locator("#hospitalisationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Hospital demand" })).toBeVisible();
@@ -94,9 +94,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${deathsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(deathsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 10_000_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 11_000_000);
   await page.locator("#deathsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 440_000);
+  await checkTimeSeriesDataPoints(page.locator(deathsTimeSeriesContainerId), 260_000);
   await expect(page.getByRole("button", { name: "New deaths" })).toBeVisible();
   await page.locator("#deathsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Dead" })).toBeVisible();
@@ -105,9 +105,9 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-xaxis-labels`)).toBeVisible();
   await expect(page.locator(`${vaccinationsTimeSeriesContainerId} .highcharts-yaxis-labels`)).toBeVisible();
   await expect(page.locator(vaccinationsTimeSeriesContainerId).getByLabel("View chart menu, Chart")).toBeVisible();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 166_000_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 100_000_000);
   await page.locator("#vaccinationsDailySwitch").check();
-  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 920_000);
+  await checkTimeSeriesDataPoints(page.locator(vaccinationsTimeSeriesContainerId), 900_000);
   await expect(page.getByRole("button", { name: "New vaccinations" })).toBeVisible();
   await page.locator("#vaccinationsDailySwitch").setChecked(false);
   await expect(page.getByRole("button", { name: "Vaccinated" })).toBeVisible();
@@ -132,30 +132,30 @@ test("Can request a scenario analysis run", async ({ page, baseURL }) => {
   expect(costsChartDataUsd[0].data.length).toBe(3);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Closures", "Closures", "Preschool-age children"]);
   expect(costsChartDataUsd[0].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 2_100_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 1_600_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 3_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[0].y, 5_700_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[1].y, 4_100_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[0].data[2].y, 3_600, costTolerance);
 
   expect(costsChartDataUsd[1].data.length).toBe(3);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.name)).toEqual(["Absences", "Absences", "School-age children"]);
   expect(costsChartDataUsd[1].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([true, true, true]);
-  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 120_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 5_000, costTolerance);
-  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 8_500_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[0].y, 190_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[1].y, 6_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[1].data[2].y, 9_900_000, costTolerance);
 
   expect(costsChartDataUsd[2].data.length).toBe(3);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Working-age adults"]);
   expect(costsChartDataUsd[2].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[2].data[0].y).toEqual(0);
   expect(costsChartDataUsd[2].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 230_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[2].data[2].y, 280_000, costTolerance);
 
   expect(costsChartDataUsd[3].data.length).toBe(3);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.name)).toEqual(["", "", "Retirement-age adults"]);
   expect(costsChartDataUsd[3].data.map((dataPoint: any) => dataPoint.custom.includeInTooltips)).toEqual([false, false, true]);
   expect(costsChartDataUsd[3].data[0].y).toEqual(0);
   expect(costsChartDataUsd[3].data[1].y).toEqual(0);
-  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 6_400_000, costTolerance);
+  checkValueIsInRange(costsChartDataUsd[3].data[2].y, 7_100_000, costTolerance);
 
   const expandCostsTableButton = page.getByTestId("toggle-costs-table");
   await expandCostsTableButton.click();


### PR DESCRIPTION
We were using a rather [different version](https://github.com/jameel-institute/daedalus.api/pull/60) of the R API (different default model options) in Singapore, and should now revert to what we had before. This necessitates changing the numbers expected by e2e tests.

The file I'm changing here (scripts/run-dependencies) isn't used in deployment, only in github actions for this repo (and local development).

I have already re-deployed https://daedalus-dev.dide.ic.ac.uk/ and https://daedalus.jameel-institute.org/ to use `main` instead of the specific image digest, as per https://github.com/jameel-institute/daedalus-deploy/blob/main/config/daedalus.yml