### PR TITLE
Update hospital capacity plot lines logic

### DIFF
--- a/components/Charts/Compare/CompareTimeSeries.client.vue
+++ b/components/Charts/Compare/CompareTimeSeries.client.vue
@@ -101,9 +101,15 @@ const hoveredScenario = computed(() => appStore.currentComparison.scenarios.find
   return runId === props.synchPoint?.series?.options?.custom?.scenarioId;
 }));
 
-const capacitiesForegroundedScenario = computed(() => {
-  const hoveredChartShowsCapacities = props.synchPoint?.series?.options?.custom?.showCapacities === true;
-  return hoveredChartShowsCapacities ? hoveredScenario.value : appStore.baselineScenario;
+// If the parameter by which we are comparing scenarios is a kind of capacity, then scenarios' capacities will vary, so
+// we should show capacities for each scenario. Otherwise, we only need to show capacities for the baseline scenario.
+const scenariosToShowCapacities = computed(() => {
+  const capacityIds = appStore.metadata?.results.capacities.map(c => c.id) ?? [];
+  const comparingByCapacity = !!appStore.currentComparison.axis && capacityIds.includes(appStore.currentComparison.axis);
+
+  return comparingByCapacity
+    ? appStore.currentComparison.scenarios
+    : [appStore.baselineScenario].filter(s => !!s);
 });
 
 // Plot the capacities as plot lines for whichever scenario's series is being hovered,
@@ -113,7 +119,7 @@ const capacitiesForegroundedScenario = computed(() => {
 const { initialCapacitiesPlotLines, initialMinRange } = useCapacitiesPlotLines(
   () => props.showCapacities,
   () => chart.value?.yAxis[0],
-  capacitiesForegroundedScenario,
+  scenariosToShowCapacities,
 );
 
 const interventionsForegroundedScenario = computed(() => {

--- a/components/Charts/Compare/CompareTimeSeriesTile.client.vue
+++ b/components/Charts/Compare/CompareTimeSeriesTile.client.vue
@@ -46,7 +46,7 @@ defineEmits<{
   updateHoverPoint: [hoverPoint: Highcharts.Point]
 }>();
 
-const toggledShowCapacities = ref(false);
+const toggledShowCapacities = ref(true);
 const appStore = useAppStore();
 const { activeSeriesMetadata } = useTimeSeriesGroup(() => props.seriesGroup, () => props.isDaily);
 const capacityLabel = computed(() => appStore.metadata?.results.capacities?.map(c => c.label.toLocaleLowerCase()).join(", "));

--- a/components/Charts/TimeSeries.client.vue
+++ b/components/Charts/TimeSeries.client.vue
@@ -61,7 +61,7 @@ const data = computed(() => getTimeSeriesDataPoints(appStore.currentScenario, pr
 const { initialCapacitiesPlotLines, initialMinRange } = useCapacitiesPlotLines(
   () => props.timeSeriesMetadata.id === "hospitalised", // https://mrc-ide.myjetbrains.com/youtrack/issue/JIDEA-118/
   () => chart.value?.yAxis[0],
-  appStore.currentScenario,
+  () => [appStore.currentScenario],
 );
 
 const { initialInterventionsPlotBands } = useInterventionPlotBands(

--- a/composables/useCapacitiesPlotLines.ts
+++ b/composables/useCapacitiesPlotLines.ts
@@ -1,49 +1,62 @@
 import { commaSeparatedNumber } from "~/components/utils/formatters";
-import { plotLinesColor, plotLinesWidthPx } from "~/components/Charts/utils/timeSeriesCharts";
+import { plotLinesColor, plotLinesWidthPx, timeSeriesColors } from "~/components/Charts/utils/timeSeriesCharts";
 import type { Scenario } from "~/types/storeTypes";
 
 export default (
   showCapacities: MaybeRefOrGetter<boolean>,
   yAxis: MaybeRefOrGetter<Highcharts.Axis | undefined>,
-  scenario: MaybeRefOrGetter<Scenario | undefined>,
+  scenarios: MaybeRefOrGetter<Scenario[]>,
 ) => {
   const appStore = useAppStore();
 
-  const capacities = computed(() => toValue(scenario)?.result.data?.capacities);
-
-  const capacitiesPlotLines = computed(() => {
-    if (!toValue(showCapacities) || !capacities.value?.length) {
+  // A flat map of each scenario's capacities.
+  // For each capacity on each scenario result, merge in some extra info we need to render the plotLines:
+  // (1) a color (matching the scenario's time-series color) in case we need one for distinguishing multiple plotLines,
+  // (2) the scenario runId which allows us to have a unique id for each plot line, and
+  // (3) a label derived from result metadata.
+  const capacities = computed(() => {
+    if (!toValue(showCapacities)) {
       return [];
     }
 
-    return capacities.value?.map(({ id, value }) => {
-      const label = appStore.metadata?.results.capacities
-        .find(({ id: capacityId }) => id === capacityId)
-        ?.label || "";
-
-      return {
-        color: plotLinesColor,
-        label: {
-          text: `${label}: ${commaSeparatedNumber(value.toString())}`,
-          style: {
-            color: plotLinesColor,
-          },
-          align: "middle",
-        },
-        dashStyle: "ShortDot",
-        width: plotLinesWidthPx,
-        value,
-        zIndex: 4, // Render label in front of the series line
-        id: `${id}-${value}-${toValue(scenario)?.runId}`, // Ensure unique id for plot line
-      };
-    }) as Array<Highcharts.AxisPlotLinesOptions>;
+    const caps: Array<{ id: string, value: number, runId: string, color: string, label: string }> = [];
+    const scens = toValue(scenarios);
+    scens.forEach(({ result, runId }, index) => {
+      if (!runId) {
+        return;
+      }
+      const color = scens.length === 1 ? plotLinesColor : timeSeriesColors[index % timeSeriesColors.length];
+      result.data?.capacities.forEach((c) => {
+        const metadataLabel = appStore.metadata?.results.capacities.find(({ id }) => c.id === id)?.label;
+        const label = `${metadataLabel}: ${commaSeparatedNumber(c.value.toString())}`;
+        caps.push({ ...c, runId, color, label });
+      });
+    });
+    return caps;
   });
+
+  // Convert capacity data to plotLine format
+  const capacitiesPlotLines = computed((): Array<Highcharts.AxisPlotLinesOptions> => capacities.value.map(c => ({
+    color: c.color,
+    label: {
+      text: capacities.value.length === 1 ? c.label : "",
+      style: {
+        color: c.color,
+      },
+      align: "middle",
+    },
+    dashStyle: "ShortDot",
+    width: plotLinesWidthPx,
+    value: c.value,
+    zIndex: 4, // Render label in front of the series line
+    id: `${c.id}-${c.value}-${c.runId}`, // Ensure unique id for plot line
+  })));
 
   // The y-axis automatically rescales to the data (ignoring the plotLines). We want the plotLines
   // to remain visible, so we limit the y-axis' ability to rescale, by defining a minimum range. This way the
   // plotLines remain visible even when the maximum data value is less than the maximum plotLine value.
   const minRange = computed(() => {
-    if (toValue(showCapacities) && capacities.value?.length) {
+    if (capacities.value?.length) {
       return capacities.value.reduce((acc, { value }) => Math.max(acc, value), 0);
     }
   });

--- a/tests/unit/components/Charts/Compare/CompareTimeSeriesTile.spec.ts
+++ b/tests/unit/components/Charts/Compare/CompareTimeSeriesTile.spec.ts
@@ -27,15 +27,23 @@ describe("timeSeriesGroup component", () => {
     const stubbedTimeSeriesComponent = component.findComponent({ name: "CompareTimeSeries.client" });
     expect(stubbedTimeSeriesComponent.props("groupIndex")).toBe(0);
     expect(stubbedTimeSeriesComponent.props("hideTooltips")).toBe(false);
-    expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
+    expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(true);
     expect(stubbedTimeSeriesComponent.props("synchPoint")).toEqual({ x: 1, y: 2 });
     const expectedTimeSeries = mockedMetadata.results.time_series.find(t => t.id === "hospitalised") as DisplayInfo;
     expect(stubbedTimeSeriesComponent.props("timeSeriesMetadata")).toEqual(expectedTimeSeries);
 
-    const showCapacitiesSwitch = component.getComponent({ name: "CFormSwitch" });
-    await showCapacitiesSwitch.setValue(true);
+    component.setProps({ isDaily: true });
+    await nextTick();
+    expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
 
+    component.setProps({ isDaily: false });
+    await nextTick();
     expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(true);
+
+    const showCapacitiesSwitch = component.getComponent({ name: "CFormSwitch" });
+    await showCapacitiesSwitch.setValue(false);
+
+    expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
 
     component.setProps({ isDaily: true });
     await nextTick();

--- a/tests/unit/components/Charts/Compare/CompareTimeSeriesTile.spec.ts
+++ b/tests/unit/components/Charts/Compare/CompareTimeSeriesTile.spec.ts
@@ -32,12 +32,10 @@ describe("timeSeriesGroup component", () => {
     const expectedTimeSeries = mockedMetadata.results.time_series.find(t => t.id === "hospitalised") as DisplayInfo;
     expect(stubbedTimeSeriesComponent.props("timeSeriesMetadata")).toEqual(expectedTimeSeries);
 
-    component.setProps({ isDaily: true });
-    await nextTick();
+    await component.setProps({ isDaily: true });
     expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
 
-    component.setProps({ isDaily: false });
-    await nextTick();
+    await component.setProps({ isDaily: false });
     expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(true);
 
     const showCapacitiesSwitch = component.getComponent({ name: "CFormSwitch" });
@@ -45,8 +43,7 @@ describe("timeSeriesGroup component", () => {
 
     expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
 
-    component.setProps({ isDaily: true });
-    await nextTick();
+    await component.setProps({ isDaily: true });
     expect(stubbedTimeSeriesComponent.props("showCapacities")).toBe(false);
   });
 

--- a/tests/unit/composables/useCapacitiesPlotLines.spec.ts
+++ b/tests/unit/composables/useCapacitiesPlotLines.spec.ts
@@ -23,14 +23,14 @@ const metadata = {
 } as Metadata;
 
 describe("useCapacitiesPlotLines", () => {
-  it("should compute capacities plot lines and update y axis correctly", async () => {
+  it("should compute capacities plot lines and update y axis correctly, for multiple capacities on a single scenario", async () => {
     setActivePinia(mockPinia({ metadata }, false, { stubActions: false }));
     const store = useAppStore();
     store.currentScenario = {
       runId: "scenario_1",
       result: {
         data: {
-          capacities: undefined,
+          capacities: [],
         },
       },
     };
@@ -62,18 +62,11 @@ describe("useCapacitiesPlotLines", () => {
     const { initialCapacitiesPlotLines, initialMinRange } = useCapacitiesPlotLines(
       showCapacities,
       yAxis,
-      store.currentScenario,
+      () => [store.currentScenario],
     );
 
     expect(initialCapacitiesPlotLines).toEqual([]);
     expect(initialMinRange).toBeUndefined();
-    expect(mockRemovePlotLine).not.toHaveBeenCalled();
-    expect(mockAddPlotLine).not.toHaveBeenCalled();
-
-    store.currentScenario.result.data.capacities = [];
-    await nextTick();
-
-    expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockRemovePlotLine).not.toHaveBeenCalled();
     expect(mockAddPlotLine).not.toHaveBeenCalled();
 
@@ -128,8 +121,108 @@ describe("useCapacitiesPlotLines", () => {
     expect(mockAddPlotLine).toHaveBeenCalledTimes(expectedCallsToAddPlotLine);
     expect(mockAddPlotLine.mock.lastCall).toEqual([expect.objectContaining({
       id: "icu_capacity-2500-scenario_1",
-      label: expect.objectContaining({ text: "ICU capacity: 2,500" }),
+      label: expect.objectContaining({ text: "" }), // No label when multiple capacities
       value: 2500,
+    })]);
+  });
+
+  it("should compute capacities plot lines and update y axis correctly, for multiple capacities across multiple scenarios", async () => {
+    setActivePinia(mockPinia({ metadata }, false, { stubActions: false }));
+    const store = useAppStore();
+    store.currentComparison = {
+      axis: "hospital_capacity",
+      baseline: "1000",
+      scenarios: [{
+        runId: "scenario_1",
+        result: {
+          data: {
+            capacities: [],
+          },
+        },
+      }, {
+        runId: "scenario_2",
+        result: {
+          data: {
+            capacities: [],
+          },
+        },
+      }],
+    };
+    store.metadata = mockMetadataResponseData;
+
+    let expectedCallsToAddPlotLine = 0;
+    let expectedCallsToRemovePlotLine = 0;
+
+    const showCapacities = ref(true);
+    const yAxis = ref({
+      update: vi.fn(arg => mockUpdate(arg)),
+      removePlotLine: vi.fn(arg => mockRemovePlotLine(arg)),
+      addPlotLine: vi.fn(arg => mockAddPlotLine(arg)),
+    } as unknown as Highcharts.Axis);
+
+    const { initialCapacitiesPlotLines, initialMinRange } = useCapacitiesPlotLines(
+      showCapacities,
+      yAxis,
+      () => store.currentComparison.scenarios,
+    );
+
+    expect(initialCapacitiesPlotLines).toEqual([]);
+    expect(initialMinRange).toBeUndefined();
+    expect(mockRemovePlotLine).not.toHaveBeenCalled();
+    expect(mockAddPlotLine).not.toHaveBeenCalled();
+
+    store.currentComparison.scenarios = [{
+      runId: "scenario_1",
+      result: {
+        data: {
+          capacities: [{
+            id: "hospital_capacity",
+            value: 1000,
+          }],
+        },
+      },
+    }, {
+      runId: "scenario_2",
+      result: {
+        data: {
+          capacities: [{
+            id: "hospital_capacity",
+            value: 2000,
+          }],
+        },
+      },
+    }];
+
+    expectedCallsToAddPlotLine += 2;
+    await nextTick();
+
+    expect(mockUpdate).toHaveBeenCalledWith({ minRange: 2000 });
+    expect(mockRemovePlotLine).not.toHaveBeenCalled();
+    expect(mockAddPlotLine).toHaveBeenCalledTimes(expectedCallsToAddPlotLine);
+    expect(mockAddPlotLine.mock.lastCall).toEqual([expect.objectContaining({
+      id: "hospital_capacity-2000-scenario_2",
+      label: expect.objectContaining({ text: "" }), // No label when multiple capacities
+      value: 2000,
+    })]);
+
+    showCapacities.value = false;
+    expectedCallsToRemovePlotLine += 2;
+    await nextTick();
+
+    expect(mockRemovePlotLine).toHaveBeenCalledTimes(expectedCallsToRemovePlotLine);
+    expect(mockRemovePlotLine.mock.lastCall).toEqual(["hospital_capacity-2000-scenario_2"]);
+    expect(mockAddPlotLine).toHaveBeenCalledTimes(expectedCallsToAddPlotLine);
+
+    showCapacities.value = true;
+    expectedCallsToAddPlotLine += 2;
+    await nextTick();
+
+    expect(mockRemovePlotLine).toHaveBeenCalledTimes(expectedCallsToRemovePlotLine);
+    expect(mockAddPlotLine).toHaveBeenCalledTimes(expectedCallsToAddPlotLine);
+    expect(mockAddPlotLine.mock.lastCall).toEqual([expect.objectContaining({
+      id: "hospital_capacity-2000-scenario_2",
+      label: expect.objectContaining({ text: "" }), // No label when multiple capacities
+      value: 2000,
     })]);
   });
 });


### PR DESCRIPTION
# Background info

A 'capacity' is, for example, the level of hospital surge capacity considered in some scenario. (Hospital surge capacity is de facto the only kind of capacity that currently exists for daedalus, but a second theoretical example could be ICU capacity.) It may be rendered in a time series, if relevant and desired by the user, as a plot line. A 'plot line' refers to a _constant_ value as rendered in a straight line (in our case a dotted line), as opposed to the actual time series itself which is not straight:

<img width="865" height="169" alt="image" src="https://github.com/user-attachments/assets/03ea3bf8-04d7-4714-bcc2-0defd2f82936" />

# Changes in this PR

Two related updates for time series' plot lines in these two commits:

1) [Show hospital capacity plotline by default in comparison](https://github.com/jameel-institute/daedalus-web-app/commit/db08d0e66c0b83cf2e73b8b365a2a6fec282b08f):

On the comparison results page (in the time series tab), we should show the hospital capacity plot line by default, rather than hide it by default. Here is the toggle you're looking for: 
<img width="269" height="45" alt="image" src="https://github.com/user-attachments/assets/76c59b56-3940-4936-899e-a74bfc16d1fa" />

2) [Update hospital capacity plot lines logic: show all scenarios' capacities if comparing by capacity](https://github.com/jameel-institute/daedalus-web-app/commit/0a7f822cc918cd40c500bf9f69d69484f0477560)

One of the possible parameters by which users can perform a comparison is hospital surge capacity. When that is the axis of comparison, scenarios' capacities are going to vary, and we have the possibility of plotting multiple plot lines on a single chart. Previously, in order to avoid plotting multiple plot lines at once, the set-up was that users could determine which scenarios' plot line was rendered in the chart by hovering over that particular scenario's time series. However, in practice, this is very fiddly to pull off, using normal human levels of mouse control, especially when the the time series you're trying to hover over are very close or actually overlap (as when they have the same values). So now, the new behaviour is just to display all scenarios' capacities at once (without text labels since these would overlap and look messy). If that is too much information, the user can still use the toggle to hide the plot lines.

In the below example, each of the three compared scenarios has the same number of hospitalised individuals for every time step throughout the course of the pandemic, and so we only see a single time series in the plot (the other lines are there too, just hidden behind the pink scenario). But we still get to see where the hospital capacity plot line is for all 3.

<img width="878" height="394" alt="image" src="https://github.com/user-attachments/assets/f4767146-cc50-4de6-879c-ac2fa2912650" />
